### PR TITLE
Fix `issue #83`

### DIFF
--- a/OlivOS/accountAPI.py
+++ b/OlivOS/accountAPI.py
@@ -163,3 +163,10 @@ class free_port_selector:
     def close(self):
         for s in self._socket_list:
             s.close()
+
+def get_free_port():
+    "注意：本函数两次分配的端口有可能相同 (详见issue #83) 。推荐改用上方 free_port_selector 在上下文中分配端口！"
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/OlivOS/accountAPI.py
+++ b/OlivOS/accountAPI.py
@@ -96,37 +96,38 @@ class Account(object):
 
 def accountFix(basic_conf_models, bot_info_dict, logger_proc):
     res = {}
-    for basic_conf_models_this in basic_conf_models:
-        if basic_conf_models[basic_conf_models_this]['type'] == 'post':
-            if basic_conf_models[basic_conf_models_this]['server']['auto'] == True:
-                basic_conf_models[basic_conf_models_this]['server']['host'] = '0.0.0.0'
-                if isInuse(
-                        '127.0.0.1',
-                        basic_conf_models[basic_conf_models_this]['server']['port']
-                ):
-                    basic_conf_models[basic_conf_models_this]['server']['port'] = get_free_port()
-    for bot_info_dict_this in bot_info_dict:
-        Account_data_this = bot_info_dict[bot_info_dict_this]
-        if platform.system() == 'Windows':
-            if Account_data_this.platform['model'] in OlivOS.libEXEModelAPI.gCheckList:
-                if Account_data_this.post_info.auto == True:
-                    Account_data_this.post_info.type = 'post'
-                    Account_data_this.post_info.host = 'http://127.0.0.1'
-                    Account_data_this.post_info.port = get_free_port()
-                    Account_data_this.post_info.access_token = bot_info_dict_this
-            if Account_data_this.platform['model'] in OlivOS.libWQEXEModelAPI.gCheckList:
-                if Account_data_this.post_info.auto == True:
-                    Account_data_this.post_info.type = 'websocket'
-                    Account_data_this.post_info.host = 'ws://127.0.0.1'
-                    Account_data_this.post_info.port = get_free_port()
-                    Account_data_this.post_info.access_token = bot_info_dict_this
-            if Account_data_this.platform['model'] in OlivOS.libCWCBEXEModelAPI.gCheckList:
-                if Account_data_this.post_info.auto == True:
-                    Account_data_this.post_info.type = 'websocket'
-                    Account_data_this.post_info.host = 'ws://127.0.0.1'
-                    Account_data_this.post_info.port = get_free_port()
-                    Account_data_this.post_info.access_token = bot_info_dict_this
-        res[bot_info_dict_this] = Account_data_this
+    with free_port_selector() as g:         # 在端口选择过程中使用上下文
+        for basic_conf_models_this in basic_conf_models:
+            if basic_conf_models[basic_conf_models_this]['type'] == 'post':
+                if basic_conf_models[basic_conf_models_this]['server']['auto'] == True:
+                    basic_conf_models[basic_conf_models_this]['server']['host'] = '0.0.0.0'
+                    if isInuse(
+                            '127.0.0.1',
+                            basic_conf_models[basic_conf_models_this]['server']['port']
+                    ):
+                        basic_conf_models[basic_conf_models_this]['server']['port'] = g.get_free_port()
+        for bot_info_dict_this in bot_info_dict:
+            Account_data_this = bot_info_dict[bot_info_dict_this]
+            if platform.system() == 'Windows':
+                if Account_data_this.platform['model'] in OlivOS.libEXEModelAPI.gCheckList:
+                    if Account_data_this.post_info.auto == True:
+                        Account_data_this.post_info.type = 'post'
+                        Account_data_this.post_info.host = 'http://127.0.0.1'
+                        Account_data_this.post_info.port = g.get_free_port()
+                        Account_data_this.post_info.access_token = bot_info_dict_this
+                if Account_data_this.platform['model'] in OlivOS.libWQEXEModelAPI.gCheckList:
+                    if Account_data_this.post_info.auto == True:
+                        Account_data_this.post_info.type = 'websocket'
+                        Account_data_this.post_info.host = 'ws://127.0.0.1'
+                        Account_data_this.post_info.port = g.get_free_port()
+                        Account_data_this.post_info.access_token = bot_info_dict_this
+                if Account_data_this.platform['model'] in OlivOS.libCWCBEXEModelAPI.gCheckList:
+                    if Account_data_this.post_info.auto == True:
+                        Account_data_this.post_info.type = 'websocket'
+                        Account_data_this.post_info.host = 'ws://127.0.0.1'
+                        Account_data_this.post_info.port = g.get_free_port()
+                        Account_data_this.post_info.access_token = bot_info_dict_this
+            res[bot_info_dict_this] = Account_data_this
     return res
 
 
@@ -141,9 +142,24 @@ def isInuse(ip, port):
         flag = False
     return flag
 
+class free_port_selector:
+    "对先前的端口获取函数进行二次包装，使得在上下文范围内不会重复生成套接字"
+    def __init__(self) -> None:
+        self._socket_list = []
 
-def get_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def get_free_port(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(('', 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket_list.append(s)     # 通过在分配端口阶段维持所有套接字，理论上可以杜绝 Issue #83
         return s.getsockname()[1]
+
+    def close(self):
+        for s in self._socket_list:
+            s.close()


### PR DESCRIPTION
通过将端口分配函数包装至上下文中，在分配的过程中不释放已分配端口，避免端口冲突。

具体测试由于很难复现该issue（本地默认顺序分配端口），在本地只能通过强制设定为固定端口进行一定程度的模拟：
~~~python
class free_port_selector:
    "对先前的端口获取函数进行二次包装，使得在上下文范围内不会重复生成套接字"
    def __init__(self) -> None:
        self._socket_list = []

    def __enter__(self):
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        self.close()

    def get_free_port(self):
        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        s.bind(('', 12345))
        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        self._socket_list.append(s)     # 通过在分配端口阶段维持所有套接字，理论上可以杜绝 Issue #83
        return s.getsockname()[1]

    def close(self):
        for s in self._socket_list:
            s.close()

def get_free_port():
    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
        s.bind(('', 12345))
        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        return s.getsockname()[1]

print("original get_free_port")
for i in range(10):
    print(i, get_free_port())

print("changed get_free_port")
with free_port_selector() as f:
    for i in range(10):
        print(i, f.get_free_port())
~~~
具体结果如下：
~~~
original get_free_port
0 12345
1 12345
2 12345
3 12345
4 12345
5 12345
6 12345
7 12345
8 12345
9 12345
changed get_free_port
0 12345
Traceback (most recent call last):
  File "d:\DICE\230606_dhu_web\1.py", line 38, in <module>
    print(i, f.get_free_port())
             ^^^^^^^^^^^^^^^^^
  File "d:\DICE\230606_dhu_web\1.py", line 16, in get_free_port
    s.bind(('', 12345))
OSError: [WinError 10048] 通常每个套接字地址(协议/网络地址/端口)只允许使用一次。
~~~