### PR TITLE
修复与LLOneBot对接时无法发送私聊消息的问题

### DIFF
--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -61,7 +61,10 @@ class send_onebot_post_json_T(object):
             return None
         else:
             try:
-                clear_dict = {k: v for k, v in self.obj.__dict__.items() if v != -1}
+                # clear_dict = {k: v for k, v in self.obj.__dict__.items() if v != -1}
+                clear_dict = self.obj.__dict__
+                if clear_dict['message_type']=='private':
+                    clear_dict.pop('group_id','No "group_id"')
                 json_str_tmp = json.dumps(obj=clear_dict, ensure_ascii=False)
                 tmp_host = self.bot_info.host
                 if tmp_host.startswith('http://') or tmp_host.startswith('https://'):

--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -61,7 +61,8 @@ class send_onebot_post_json_T(object):
             return None
         else:
             try:
-                json_str_tmp = json.dumps(obj=self.obj.__dict__, ensure_ascii=False)
+                clear_dict = {k: v for k, v in self.obj.__dict__.items() if v != -1}
+                json_str_tmp = json.dumps(obj=clear_dict, ensure_ascii=False)
                 tmp_host = self.bot_info.host
                 if tmp_host.startswith('http://') or tmp_host.startswith('https://'):
                     pass


### PR DESCRIPTION
LLOneBot的私聊消息发送接口收到的json中如果存在`group_id`键就无法发送，OlivOS中的私聊json中会有`group_id : -1`这个键值对，删除就可以正常发送。

**个人原因，测试可能并不全面。**

注释掉的这段怕会导致其他的功能出错（但我大概看了一下应该不影响？），以防万一写了只针对私聊（private）的过滤。