### PR TITLE
删除send_group_msg里面的user_id字段，更适配onebotV11

### DIFF
--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -549,6 +549,8 @@ class event_action(object):
         this_msg = api.send_msg(get_SDK_bot_info_from_Event(target_event))
         this_msg.data.message_type = 'group'
         this_msg.data.group_id = str(group_id)
+        if hasattr(this_msg.data, 'user_id'):
+            del this_msg.data.user_id
         if target_event.bot_info.platform['model'] in paraMsgMap:
             msgType = 'para'
         this_msg.data.message = formatMessage(data = message, msgType = msgType)


### PR DESCRIPTION
根据 OneBotV11 文档里的[onebot-11/api/public - send_msg - 发送消息](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#send_msg-%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF)，send_group_msg字段并不需要user_id，而青果默认user_id传入为-1，故将这里的user_id删除，以更好的适配协议