### PR TITLE
fix: 补全OneBot11反向WS的消息回路，使响应传导路径符合预期 + 驱动器优化

### DIFF
--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -48,6 +48,8 @@ lagrangeModelMap = [
 
 gFlagCheckList = []
 
+gResReg = {}
+
 
 class bot_info_T(object):
     def __init__(self, id=-1, host='', port=-1, access_token=None):
@@ -136,17 +138,17 @@ class send_onebot_post_json_T(object):
                 if clear_dict.get('message_type') == 'private':
                     clear_dict.pop('group_id', 'No "group_id"')
                 json_str_tmp = json.dumps(obj=clear_dict, ensure_ascii=False)
-                tmp_host = self.bot_info.host
-                if tmp_host.startswith('http://') or tmp_host.startswith('https://'):
-                    pass
+
+                if self.bot_info.host.startswith('http://') or self.bot_info.host.startswith('https://'):
+                    protocol_header = ''
                 else:
-                    tmp_host = 'http://' + tmp_host
+                    protocol_header = 'http://'
                 token_str = ''
                 token_dict = {}
                 if len(self.bot_info.access_token) > 0:
                     token_str = f'?access_token={self.bot_info.access_token}'
                     token_dict = {'Authorization': f'Bearer {self.bot_info.access_token}'}
-                send_url = f'{self.bot_info.host}:{self.bot_info.port}/{self.node_ext}{token_str}'
+                send_url = f'{protocol_header}{self.bot_info.host}:{self.bot_info.port}/{self.node_ext}{token_str}'
 
                 if self.bot_info.debug_mode:
                     if self.bot_info.debug_logger is not None:
@@ -172,8 +174,12 @@ class api_templet(object):
         self.bot_info = None
         self.data = None
         self.node_ext = None
-        self.echo = uuid.uuid4()
-        self.res = None
+        self.echo = str(uuid.uuid4())
+        self.res: api_templet.Result = None
+
+    class Result(object):
+        def __init__(self, raw: str | dict):
+            self.body = raw
 
     def do_api(self, control_queue=None):
         server_type = self.bot_info.server_type
@@ -183,29 +189,36 @@ class api_templet(object):
             this_post_json.obj = self.data
             this_post_json.node_ext = self.node_ext
             try:
-                self.res = this_post_json.send_onebot_post_json()
+                tmp_raw = this_post_json.send_onebot_post_json()
+                self.res = self.Result(tmp_raw.text)
             except Exception:
                 self.res = None
         elif server_type == "websocket":
             try:
                 bot_hash = self.bot_info.hash
                 data = self.do_dump()
+                waitForResReady(self.echo)
                 self.res = send_ws_event(
                     hash=bot_hash,
                     data=data,
                     control_queue=control_queue
                 )
+                tmp_raw = waitForRes(self.echo)
+                self.res = self.Result(tmp_raw)
             except Exception:
                 self.res = None
         elif server_type == "websocket_host":
             try:
                 bot_hash = self.bot_info.hash
                 data = self.do_dump()
-                self.res = send_ws_event(
+                waitForResReady(self.echo)
+                send_ws_event(
                     hash=bot_hash,
                     data=data,
                     control_queue=control_queue
                 )
+                tmp_raw = waitForRes(self.echo)
+                self.res = self.Result(tmp_raw)
             except Exception:
                 self.res = None
         return self.res
@@ -214,6 +227,7 @@ class api_templet(object):
         res_obj = {
             'action': self.node_ext,
             'params': {},
+            'echo': self.echo
         }
         if self.data is not None:
             for key_this in self.data.__dict__:
@@ -253,17 +267,16 @@ class api_templet(object):
         ):
             return None
         try:
-            tmp_host = self.bot_info.host
-            if tmp_host.startswith('http://') or tmp_host.startswith('https://'):
-                pass
+            if self.bot_info.host.startswith('http://') or self.bot_info.host.startswith('https://'):
+                protocol_header = ''
             else:
-                tmp_host = 'http://' + tmp_host
+                protocol_header = 'http://'
             token_str = ''
             token_dict = {}
             if len(self.bot_info.access_token) > 0:
                 token_str = f'?access_token={self.bot_info.access_token}'
                 token_dict = {'Authorization': f'Bearer {self.bot_info.access_token}'}
-            send_url = f'{self.bot_info.host}:{self.bot_info.port}/{self.node_ext}{token_str}'
+            send_url = f'{protocol_header}{self.bot_info.host}:{self.bot_info.port}/{self.node_ext}{token_str}'
             if self.bot_info.debug_mode:
                 if self.bot_info.debug_logger is not None:
                     self.bot_info.debug_logger.log(0, self.node_ext + ': GET request')
@@ -282,7 +295,7 @@ class api_templet(object):
 
 
 class event(object):
-    def __init__(self, raw):
+    def __init__(self, raw, extras: dict = None):
         self.raw = raw
         self.json = self.event_load(raw)
         self.platform = {'sdk': 'onebot', 'platform': 'qq', 'model': 'default'}
@@ -291,9 +304,19 @@ class event(object):
             self.active = True
         self.base_info = {}
         if self.active:
-            self.base_info['time'] = self.json['time']
-            self.base_info['self_id'] = self.json['self_id']
-            self.base_info['post_type'] = self.json['post_type']
+            if 'retcode' not in self.json:
+                # 以retcode字段区分事件上报/API响应
+                self.base_info['time'] = self.json['time']
+                self.base_info['self_id'] = self.json['self_id']
+                self.base_info['post_type'] = self.json['post_type']
+            if extras is not None:
+                # 兼容新的websocket驱动器(onebotV11HostServer)
+                if 'id' in extras:
+                    self.base_info['self_id'] = extras['id']
+                if 'token' in extras:
+                    self.base_info['token'] = extras['token']
+                if 'type' in extras:
+                    self.base_info['server_type'] = extras['type']
 
     def event_load(self, raw):
         try:
@@ -338,13 +361,23 @@ def format_cq_code_msg(msg):
 # 支持OlivOS API事件生成的映射实现
 def get_Event_from_SDK(target_event):
     target_event.base_info['time'] = target_event.sdk_event.base_info.get('time', int(time.time()))
-    target_event.base_info['self_id'] = str(target_event.sdk_event.base_info['self_id'])
-    target_event.base_info['type'] = target_event.sdk_event.base_info['post_type']
+    target_event.base_info['self_id'] = str(target_event.sdk_event.base_info.get('self_id', '-1'))
+    target_event.base_info['type'] = target_event.sdk_event.base_info.get('post_type', 'None')
     target_event.platform['sdk'] = target_event.sdk_event.platform['sdk']
     target_event.platform['platform'] = target_event.sdk_event.platform['platform']
     target_event.platform['model'] = target_event.sdk_event.platform['model']
     target_event.plugin_info['message_mode_rx'] = 'old_string'
-    if target_event.base_info['type'] == 'message_sent':
+    if (
+        'retcode' in target_event.sdk_event.json
+        and 'echo' in target_event.sdk_event.json
+        and type(target_event.sdk_event.json['echo']) is str
+    ):
+        target_event.active = False
+        waitForResSet(
+            target_event.sdk_event.json['echo'],
+            target_event.sdk_event.json
+        )
+    elif target_event.base_info['type'] == 'message_sent':
         """_自身消息事件_
         添加`message_sent`事件,详见:https://docs.go-cqhttp.org/event/#%E6%89%80%E6%9C%89%E4%B8%8A%E6%8A%A5
         """
@@ -723,7 +756,7 @@ class event_action(object):
         this_msg.data.message_id = str(message_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -749,7 +782,7 @@ class event_action(object):
         this_msg.data.id = str(message_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -903,7 +936,7 @@ class event_action(object):
         this_msg = api.get_login_info(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -920,7 +953,7 @@ class event_action(object):
         this_msg.data.no_cache = no_cache
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -935,7 +968,7 @@ class event_action(object):
         this_msg = api.get_friend_list(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -955,7 +988,7 @@ class event_action(object):
         this_msg.data.no_cache = no_cache
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -973,7 +1006,7 @@ class event_action(object):
         this_msg = api.get_group_list(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -982,10 +1015,12 @@ class event_action(object):
                     tmp_res_data_this['name'] = init_api_do_mapping_for_dict(raw_obj_this, ['group_name'], str)
                     tmp_res_data_this['id'] = str(init_api_do_mapping_for_dict(raw_obj_this, ['group_id'], int))
                     tmp_res_data_this['memo'] = init_api_do_mapping_for_dict(raw_obj_this, ['group_memo'], str)
-                    tmp_res_data_this['member_count'] = init_api_do_mapping_for_dict(raw_obj_this, ['member_count'],
-                                                                                     int)
-                    tmp_res_data_this['max_member_count'] = init_api_do_mapping_for_dict(raw_obj_this,
-                                                                                         ['max_member_count'], int)
+                    tmp_res_data_this['member_count'] = init_api_do_mapping_for_dict(
+                        raw_obj_this, ['member_count'], int
+                    )
+                    tmp_res_data_this['max_member_count'] = init_api_do_mapping_for_dict(
+                        raw_obj_this, ['max_member_count'], int
+                    )
                     res_data['data'].append(tmp_res_data_this)
         return res_data
 
@@ -999,7 +1034,7 @@ class event_action(object):
         this_msg.data.no_cache = no_cache
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1008,11 +1043,12 @@ class event_action(object):
                 res_data['data']['user_id'] = str(init_api_do_mapping_for_dict(raw_obj, ['user_id'], int))
                 res_data['data']['group_id'] = str(init_api_do_mapping_for_dict(raw_obj, ['group_id'], int))
                 res_data['data']['times']['join_time'] = init_api_do_mapping_for_dict(raw_obj, ['join_time'], int)
-                res_data['data']['times']['last_sent_time'] = init_api_do_mapping_for_dict(raw_obj, ['last_sent_time'],
-                                                                                           int)
-                res_data['data']['times']['shut_up_timestamp'] = init_api_do_mapping_for_dict(raw_obj,
-                                                                                              ['shut_up_timestamp'],
-                                                                                              int)
+                res_data['data']['times']['last_sent_time'] = init_api_do_mapping_for_dict(
+                    raw_obj, ['last_sent_time'], int
+                )
+                res_data['data']['times']['shut_up_timestamp'] = init_api_do_mapping_for_dict(
+                    raw_obj, ['shut_up_timestamp'], int
+                )
                 res_data['data']['role'] = init_api_do_mapping_for_dict(raw_obj, ['role'], str)
                 res_data['data']['card'] = init_api_do_mapping_for_dict(raw_obj, ['card'], str)
                 res_data['data']['title'] = init_api_do_mapping_for_dict(raw_obj, ['title'], str)
@@ -1026,7 +1062,7 @@ class event_action(object):
         this_msg.data.group_id = int(group_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -1036,12 +1072,15 @@ class event_action(object):
                     tmp_res_data_this['id'] = str(init_api_do_mapping_for_dict(raw_obj_this, ['user_id'], int))
                     tmp_res_data_this['user_id'] = str(init_api_do_mapping_for_dict(raw_obj_this, ['user_id'], int))
                     tmp_res_data_this['group_id'] = str(init_api_do_mapping_for_dict(raw_obj_this, ['group_id'], int))
-                    tmp_res_data_this['times']['join_time'] = init_api_do_mapping_for_dict(raw_obj_this, ['join_time'],
-                                                                                           int)
-                    tmp_res_data_this['times']['last_sent_time'] = init_api_do_mapping_for_dict(raw_obj_this,
-                                                                                                ['last_sent_time'], int)
-                    tmp_res_data_this['times']['shut_up_timestamp'] = init_api_do_mapping_for_dict(raw_obj_this, [
-                        'shut_up_timestamp'], int)
+                    tmp_res_data_this['times']['join_time'] = init_api_do_mapping_for_dict(
+                        raw_obj_this, ['join_time'], int
+                    )
+                    tmp_res_data_this['times']['last_sent_time'] = init_api_do_mapping_for_dict(
+                        raw_obj_this, ['last_sent_time'], int
+                    )
+                    tmp_res_data_this['times']['shut_up_timestamp'] = init_api_do_mapping_for_dict(
+                        raw_obj_this, ['shut_up_timestamp'], int
+                    )
                     tmp_res_data_this['role'] = init_api_do_mapping_for_dict(raw_obj_this, ['role'], str)
                     tmp_res_data_this['card'] = init_api_do_mapping_for_dict(raw_obj_this, ['card'], str)
                     tmp_res_data_this['title'] = init_api_do_mapping_for_dict(raw_obj_this, ['title'], str)
@@ -1055,7 +1094,7 @@ class event_action(object):
         this_msg = api.can_send_image(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1069,7 +1108,7 @@ class event_action(object):
         this_msg = api.can_send_record(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1083,7 +1122,7 @@ class event_action(object):
         this_msg = api.get_status(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1137,7 +1176,7 @@ class event_action(object):
         this_msg = api.get_version_info(get_SDK_bot_info_from_Event(target_event))
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1167,7 +1206,7 @@ class event_action(object):
         this_msg.data.user_id = int(user_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1191,7 +1230,7 @@ class event_action(object):
         this_msg.data.group_id = int(group_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -1290,7 +1329,7 @@ class event_action(object):
         this_msg.data.group_id = int(group_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1312,7 +1351,7 @@ class event_action(object):
             this_msg.data.file_count = int(file_count)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1333,7 +1372,7 @@ class event_action(object):
             this_msg.data.file_count = int(file_count)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1351,7 +1390,7 @@ class event_action(object):
         this_msg.data.busid = int(busid)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1418,7 +1457,7 @@ class event_action(object):
         this_msg.data.group_id = int(group_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -1459,7 +1498,7 @@ class event_action(object):
             this_msg.data.group_id = int(group_id)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -1488,7 +1527,7 @@ class event_action(object):
         this_msg.data.count = int(count)
         this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, list):
                 res_data['active'] = True
@@ -1525,7 +1564,7 @@ class event_action(object):
             this_msg.data.count = int(count)
             this_msg.do_api(control_queue=control_queue)
         if this_msg.res is not None:
-            raw_obj = init_api_json(this_msg.res.text)
+            raw_obj = init_api(this_msg.res.body)
         if raw_obj is not None:
             if isinstance(raw_obj, dict):
                 res_data['active'] = True
@@ -1611,7 +1650,16 @@ class event_action(object):
                 this_msg.do_api(control_queue=control_queue)
 
 
-def init_api_json(raw_str):
+def init_api(raw: str | dict) -> dict:
+    res_data = None
+    if isinstance(raw, str):
+        res_data = init_api_json_str(raw)
+    elif isinstance(raw, dict):
+        res_data = init_api_json_obj(raw)
+    return res_data
+
+
+def init_api_json_str(raw_str: str) -> dict | None:
     res_data = None
     tmp_obj = None
     flag_is_active = False
@@ -1631,9 +1679,30 @@ def init_api_json(raw_str):
     if flag_is_active:
         if 'data' in tmp_obj:
             if isinstance(tmp_obj['data'], dict):
-                res_data = tmp_obj['data'].copy()
+                res_data = tmp_obj['data']
             elif isinstance(tmp_obj['data'], list):
-                res_data = tmp_obj['data'].copy()
+                res_data = tmp_obj['data']
+    return res_data
+
+
+def init_api_json_obj(raw_obj: dict) -> dict | None:
+    tmp_obj = raw_obj
+    res_data = None
+    flag_is_active = False
+    if 'status' in tmp_obj:
+        if isinstance(tmp_obj['status'], str):
+            if tmp_obj['status'] == 'ok':
+                flag_is_active = True
+    if 'retcode' in tmp_obj:
+        if isinstance(tmp_obj['retcode'], int):
+            if tmp_obj['retcode'] == 0:
+                flag_is_active = True
+    if flag_is_active:
+        if 'data' in tmp_obj:
+            if isinstance(tmp_obj['data'], dict):
+                res_data = tmp_obj['data']
+            elif isinstance(tmp_obj['data'], list):
+                res_data = tmp_obj['data']
     return res_data
 
 
@@ -2612,3 +2681,29 @@ class api(object):
             def __init__(self):
                 self.message_id = -1
                 self.emoji_id = -1
+
+
+def waitForResSet(echo: str, data):
+    if echo in gResReg:
+        gResReg[echo] = data
+
+
+def waitForResReady(echo: str):
+    gResReg[echo] = None
+
+
+def waitForRes(echo: str):
+    res = None
+    interval = 0.1
+    limit = 30
+    index_limit = int(limit / interval)
+    for i in range(index_limit):
+        time.sleep(interval)
+        if (
+            echo in gResReg
+            and gResReg[echo] is not None
+        ):
+            res = gResReg[echo]
+            gResReg.pop(echo)
+            break
+    return res

--- a/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
+++ b/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
@@ -11,7 +11,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
 @Contact   :   RemiliaNero@gmail.com
 @License   :   AGPL
 @Copyright :   (C) 2020-2026, OlivOS-Team
-@Desc      :   OneBot11 WebSocket Server Implementation
+@Desc      :   OneBot11 WebSocket-Reverse Server Implementation
 '''
 
 import json
@@ -20,7 +20,9 @@ import asyncio
 import threading
 import traceback
 import websockets
+import multiprocessing
 from websockets import Response, Headers
+from dataclasses import dataclass
 import http
 
 import OlivOS
@@ -36,19 +38,27 @@ DEFAULT_DEAD_INTERVAL = 1
 QUEUE_TIMEOUT = 0.1
 
 
+@dataclass
+class ServerConf:
+    host: str
+    port: int
+    token: str
+    type: str
+
+
 class server(OlivOS.API.Proc_templet):
     """OneBot11 反向WebSocket 服务器
 
     Args:
     - Proc_name: 进程名称
-    - scan_interval: 扫描间隔，单位秒，默认为0.001s
-    - dead_interval: 枪毙间隔，单位秒，默认为1s
-    - rx_queue: 接收队列，默认为None
-    - tx_queue: 发送队列，默认为None
-    - control_queue: 控制队列，默认为None
-    - logger_proc: 日志进程，用于记录日志，默认为None
-    - debug_mode: 调试模式，默认为False
-    - bot_info_dict: 机器人信息字典，包含host、port、access_token等信息，默认为None
+    - scan_interval: 扫描间隔,单位秒,默认为0.001s
+    - dead_interval: 枪毙间隔,单位秒,默认为1s
+    - rx_queue: 接收队列,默认为None
+    - tx_queue: 发送队列,默认为None
+    - control_queue: 控制队列,默认为None
+    - logger_proc: 日志进程,用于记录日志,默认为None
+    - debug_mode: 调试模式,默认为False
+    - bot_info_dict: 机器人信息字典,包含host、port、access_token等信息,默认为None
     """
 
     def __init__(
@@ -74,47 +84,88 @@ class server(OlivOS.API.Proc_templet):
             control_queue=control_queue,
             logger_proc=logger_proc
         )
-        self.Proc_config['debug_mode'] = debug_mode
-        self.Proc_config['host'] = bot_info_dict.post_info.host
-        if (
-            self.Proc_config['host'].startswith('ws://')
-            or self.Proc_config['host'].startswith('wss://')
-        ):
-            self.Proc_config['host'] = self.Proc_config['host'].split('://', 1)[1]
-        self.Proc_config['port'] = bot_info_dict.post_info.port
-        self.Proc_config['access_token'] = bot_info_dict.post_info.access_token
-        self.Proc_data['bot_info_dict'] = bot_info_dict
+        self.debug_mode = debug_mode
+        tmp_host = bot_info_dict.post_info.host
+        if tmp_host.startswith('ws://') or tmp_host.startswith('wss://'):
+            tmp_host = tmp_host.split('://', 1)[1]
+        tmp_port = bot_info_dict.post_info.port
+        tmp_token = bot_info_dict.post_info.access_token
+        tmp_type = bot_info_dict.post_info.type
+        self.conf = ServerConf(
+            host=tmp_host,
+            port=tmp_port,
+            token=tmp_token,
+            type=tmp_type
+        )
+        self.bot_info = bot_info_dict   # 其实是个bot_info_T对象
+        self.async_rx_queue = None
 
     def start(self) -> threading.Thread:
-        """重写自基类的start方法，强制使用线程来运行事件循环"""
+        """重写自基类的start方法,强制使用线程来运行事件循环
+
+        Returns:
+        - threading.Thread: 运行事件循环的线程对象
+        """
         proc_this = threading.Thread(
             target=lambda: asyncio.run(self.run()),
             name=self.Proc_name
         )
-        proc_this.daemon = self.deamon
+        proc_this.daemon = self.deamon  # 依旧仑质神秘小巧思
         proc_this.start()
         # self.Proc = proc_this
         return proc_this
 
     def start_unity(self, mode: str = 'threading') -> threading.Thread:
-        """重写自基类的start_unity方法，强制使用线程来运行事件循环
+        """重写自基类的start_unity方法,强制使用线程来运行事件循环
 
-        OlivOS是基于多线程/多进程设计的，事件循环必须在独立线程中运行，因此不支持其他模式
+        OlivOS是基于多线程/多进程设计的,事件循环必须在独立线程中运行,因此不支持其他模式
 
         Args:
-        - mode: 启动模式，默认为'threading'，目前仅支持线程，且无法根据传入值切换"""
+        - mode: 启动模式,默认为'threading',目前仅支持线程,且无法根据传入值切换
+
+        Returns:
+        - threading.Thread: 运行事件循环的线程对象
+        """
         proc_this = self.start()
         return proc_this
 
+    async def producer(self, websocket: websockets.ServerConnection) -> None:
+        """生产者,即发送逻辑的执行者
+
+        Args:
+        - websocket: WebSocket连接对象, 用于发送消息
+        """
+        while True:
+            rx_packet_data: OlivOS.API.Control.packet = await self.async_rx_queue.get()
+            try:
+                data_part: dict = rx_packet_data.key.get('data', {})
+                if data_part.get('action') == 'send':
+                    payload = data_part.get('data')
+                    if payload is not None:
+                        if isinstance(payload, (dict, list)):
+                            payload = json.dumps(payload)
+                        await websocket.send(payload)
+            except websockets.ConnectionClosed:
+                break
+            except Exception as e:
+                self.on_error(e)
+            finally:
+                self.async_rx_queue.task_done()
+
     async def consumer(self, websocket: websockets.ServerConnection) -> None:
-        """消费者，即接收逻辑的执行者
+        """消费者,即接收逻辑的执行者
 
         Args:
         - websocket: WebSocket连接对象, 用于接收消息
         """
         async for raw_message in websocket:
             try:
-                sdk_event = OlivOS.onebotSDK.event(raw_message)
+                extra_info = {
+                    'id': self.bot_info.id,
+                    'token': self.conf.token,
+                    'type': self.conf.type,
+                }
+                sdk_event = OlivOS.onebotSDK.event(raw_message, extra_info)
                 if not sdk_event.active:
                     continue
                 tx_packet_data = OlivOS.pluginAPI.shallow.rx_packet(sdk_event)
@@ -122,37 +173,56 @@ class server(OlivOS.API.Proc_templet):
             except Exception as e:
                 self.on_error(e)
 
-    async def producer(self, websocket: websockets.ServerConnection) -> None:
-        """生产者，即发送逻辑的执行者
+    def bridger(self, loop: asyncio.AbstractEventLoop) -> None:
+        """队列桥接者
+        单独开一个线程将rx_queue的数据搬运到异步队列,以此规避producer频繁调用to_thread带来的性能问题
+        这基于rx_queue是multiprocessing.Queue对象, 事实上也的确是
 
         Args:
-        - websocket: WebSocket连接对象, 用于发送消息
+        - loop: 当前事件循环对象
+        - async_rx_queue: producer使用的异步队列,用于接收数据
         """
         while True:
-            rx_packet_data = None
             try:
-                if not self.Proc_info.rx_queue.empty():
-                    rx_packet_data = await asyncio.to_thread(
-                        self.Proc_info.rx_queue.get_nowait  # 使用非阻塞的get_nowait
-                    )
-            except Exception:
-                # 如果没有数据则等待
-                await asyncio.sleep(QUEUE_TIMEOUT)
-                continue
+                rx_packet_data = self.Proc_info.rx_queue.get()
+                asyncio.run_coroutine_threadsafe(
+                    self.async_rx_queue.put(rx_packet_data),
+                    loop
+                )
+            except EOFError:
+                break
+            except Exception as e:
+                self.on_error(e)
 
-            if rx_packet_data is not None:
-                try:
-                    data_part = rx_packet_data.key.get('data', {})
-                    if data_part.get('action') == 'send':
-                        payload = data_part.get('data')
-                        if payload:
-                            if isinstance(payload, (dict, list)):
-                                payload = json.dumps(payload)
-                            await websocket.send(payload)
-                except Exception as e:
-                    self.on_error(e)
-            else:
-                await asyncio.sleep(QUEUE_TIMEOUT)
+    def auther(
+            self,
+            connection: websockets.ServerConnection,
+            request: websockets.Request
+    ) -> Response | None:
+        """验证者,即鉴权逻辑的执行者
+        为WebSocket服务器的process_request回调函数
+
+        Args:
+        - connection: WebSocket连接对象,未使用
+        - request: WebSocket请求对象
+
+        Returns:
+        - Response | None: None表示成功,否则返回Response对象
+        """
+        token = self.conf.token
+        if not token:
+            return None
+        auth_header = request.headers.get('Authorization')
+        if auth_header != f"Bearer {token}" and auth_header != token:
+            client_token = auth_header.replace('Bearer ', '') if auth_header else 'None'
+            self.on_unauth(client_token)
+            return Response(
+                http.HTTPStatus.UNAUTHORIZED,
+                reason_phrase='Unauthorized',
+                headers=Headers(),
+                body=b'Unauthorized'
+            )
+        return None
 
     async def handler(self, websocket: websockets.ServerConnection) -> None:
         """处理WebSocket连接的协程
@@ -169,7 +239,6 @@ class server(OlivOS.API.Proc_templet):
                 [consumer_task, producer_task],
                 return_when=asyncio.FIRST_COMPLETED,
             )
-
             # 取消所有待处理的任务
             for task in pending:
                 task.cancel()
@@ -179,83 +248,57 @@ class server(OlivOS.API.Proc_templet):
                     pass
                 except Exception as e:
                     self.on_error(e)
-
-            # 取消所有任务
-            for task in [consumer_task, producer_task]:
-                if not task.done():
-                    task.cancel()
-                    try:
-                        await task
-                    except asyncio.CancelledError:
-                        pass
-                    except Exception as e:
-                        self.on_error(e)
         finally:
             self.on_close()
 
     async def run(self) -> None:
         """运行WebSocket服务器的主协程"""
-        if not is_free_port(self.Proc_config['port']):
+        if not is_free_port(self.conf.host, self.conf.port):
             self.log(
                 3,
                 OlivOS.L10NAPI.getTrans(
                     'OlivOS onebotV11 host server [{0}] websocket link port [{1}] is in use',
-                    [self.Proc_name, self.Proc_config['port']],
+                    [self.Proc_name, self.conf.port],
                     modelName
                 )
             )
             self.on_lost()
             return
 
+        loop = asyncio.get_running_loop()
+        self.async_rx_queue = asyncio.Queue(maxsize=512)
+        bridger_thread = threading.Thread(
+            target=self.bridger,
+            args=(loop,),
+            name=f'{self.Proc_name}-Bridger',
+            daemon=True
+        )
+        bridger_thread.start()
+
+        while True:
+            async with websockets.serve(
+                self.handler,
+                self.conf.host,
+                self.conf.port,
+                process_request=self.auther
+            ):
+                self.on_run()
+                await asyncio.Future()  # run forever
+            self.on_lost()
+
+    def on_run(self) -> None:
+        """服务器启动时的处理"""
         self.log(
             2,
             OlivOS.L10NAPI.getTrans(
                 'OlivOS onebotV11 host server [{0}] is running on [{1}]',
                 [
                     self.Proc_name,
-                    f"ws://{self.Proc_config['host']}:{self.Proc_config['port']}"
+                    f"ws://{self.conf.host}:{self.conf.port}"
                 ],
                 modelName
             )
         )
-
-        def process_request(
-            connection: websockets.ServerConnection,
-            request: websockets.Request
-        ) -> Response | None:
-            """验证客户端的访问令牌"""
-            access_token = self.Proc_config.get('access_token', '')
-            if not access_token:
-                return None
-            auth_header = request.headers.get('Authorization')
-            if auth_header != f"Bearer {access_token}" and auth_header != access_token:
-                client_token = auth_header.replace('Bearer ', '') if auth_header else 'None'
-                self.log(
-                    3,
-                    OlivOS.L10NAPI.getTrans(
-                        'OlivOS onebotV11 host server [{0}] websocket link unauthorized token: [{1}]',
-                        [self.Proc_name, client_token],
-                        modelName
-                    )
-                )
-                res = Response(
-                    http.HTTPStatus.UNAUTHORIZED,
-                    reason_phrase='Unauthorized',
-                    headers=Headers(),
-                    body=b'Unauthorized'
-                )
-                return res
-            return None
-
-        while True:
-            async with websockets.serve(
-                self.handler,
-                self.Proc_config['host'],
-                self.Proc_config['port'],
-                process_request=process_request
-            ):
-                await asyncio.Future()  # run forever
-            self.on_lost()
 
     def on_open(self) -> None:
         """连接建立时的处理"""
@@ -301,16 +344,31 @@ class server(OlivOS.API.Proc_templet):
             )
         )
 
+    def on_unauth(self, token: str) -> None:
+        """未验证通过的处理"""
+        self.log(
+            3,
+            OlivOS.L10NAPI.getTrans(
+                'OlivOS onebotV11 host server [{0}] websocket link unauthorized token: [{1}]',
+                [self.Proc_name, token],
+                modelName
+            )
+        )
 
-def is_free_port(port: int) -> bool:
+
+def is_free_port(host: str, port: int) -> bool:
     """检查端口是否可用"""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('127.0.0.1', port)) != 0
+        try:
+            s.bind((host, port))
+            return True
+        except OSError:
+            return False
 
 
-def get_free_port() -> int:
+def get_free_port(host: str) -> int:
     """获取一个可用的端口号"""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('127.0.0.1', 0))
+        s.bind((host, 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]

--- a/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
+++ b/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
@@ -20,7 +20,6 @@ import asyncio
 import threading
 import traceback
 import websockets
-import multiprocessing
 from websockets import Response, Headers
 from dataclasses import dataclass
 import http


### PR DESCRIPTION
### onebotSDK.py
- `api_templet`类的`do_api`方法在ws分支下使用wait原语
- `api_templet`类的`res`属性统一使用内建Result结构体
- 修复`send_onebot_post_json`在的协议头失效问题
- 更名`init_api_json`为`init_api`，以符合新增允许dict入参的调整

### onebotV11HostServer.py
- 适当拆分逻辑以解耦：`auther`、`bridger`
- 将部分日志记录复用，提升为on方法：`on_unauth`
- 优化is_free_port函数的逻辑，基于可连接->基于可绑定
- 放弃`Proc_config`与`Proc_data`来记录服务器配置与服务器数据
- 新增`bridger`方法用以桥接队列，优化性能

_Follow-up to #165_ 