### PR TITLE
fix(OB11WS): 修正extra_info中type字段的映射来源错误

### DIFF
--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -317,6 +317,8 @@ class event(object):
                     self.base_info['self_id'] = extras['id']
                 if 'type' in extras:
                     self.base_info['server_type'] = extras['type']
+                if 'token' in extras:
+                    self.base_info['access_token'] = extras['token']
 
     def event_load(self, raw):
         try:

--- a/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
+++ b/OlivOS/adapter/onebotV11/onebotV11HostServerAPI.py
@@ -196,7 +196,8 @@ class server(OlivOS.API.Proc_templet):
             try:
                 extra_info = {
                     'id': self.bot_info.id,
-                    'type': self.conf.type,
+                    'token': self.conf.token,
+                    'type': 'websocket_host'
                 }
                 sdk_event = OlivOS.onebotSDK.event(raw_message, extra_info)
                 if not sdk_event.active:


### PR DESCRIPTION
Follow-up to #165

## Summary by Sourcery

Fix OneBot V11 websocket host extra_info metadata for events.

Bug Fixes:
- Correct the server type reported in OneBot V11 websocket host extra_info to use a fixed websocket_host value instead of the adapter config type.
- Propagate the websocket host access token into the OneBot SDK base_info for proper metadata exposure.