### PR TITLE
修正QQ群主动消息判定，完善qqGuildV2SDK富媒体与 OneBot、Milky 文件发送，完善 QQGuildV2SDK Markdown 相关格式的支持

### DIFF
--- a/OlivOS/adapter/milky/milkySDK.py
+++ b/OlivOS/adapter/milky/milkySDK.py
@@ -15,6 +15,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
 
 import OlivOS
 
+import base64
 import os
 import time
 import uuid
@@ -893,6 +894,32 @@ class event(object):
         return raw
 
 
+def _format_file_uri(file: str) -> str:
+    if not isinstance(file, str):
+        return file
+    file_parsed = parse.urlparse(file)
+    if file_parsed.scheme.lower() in ['file', 'http', 'https', 'base64']:
+        return file
+    if file_parsed.scheme.lower() == 'data' and ',' in file:
+        data_meta, data_raw = file.split(',', 1)
+        if data_meta.endswith(';base64'):
+            return 'base64://' + data_raw
+        return 'base64://' + base64.b64encode(
+            parse.unquote_to_bytes(data_raw)
+        ).decode('ascii')
+    flag_local_absolute = (
+        os.path.isabs(file)
+        or (len(file) > 1 and file[1] == ':')
+        or file.startswith('\\\\')
+    )
+    if not flag_local_absolute and file_parsed.scheme != '':
+        return file
+    file_path = file
+    if not flag_local_absolute:
+        file_path = OlivOS.contentAPI.resourcePathTransform('files', file_path)
+    return Path(file_path).absolute().as_uri()
+
+
 class event_action(object):
     """支持OlivOS API调用的方法实现"""
 
@@ -1612,7 +1639,7 @@ class event_action(object):
         folder_id = folder_id if folder_id else '/'
         Action = API.upload_group_file(
             group_id=group_id,
-            file_uri=file,
+            file_uri=_format_file_uri(file),
             file_name=name,
             parent_folder_id=folder_id,
         )
@@ -1758,7 +1785,7 @@ class event_action(object):
         user_id = int(user_id)
         Action = API.upload_private_file(
             user_id=user_id,
-            file_uri=file,
+            file_uri=_format_file_uri(file),
             file_name=name,
         )
         Action.call(bot_hash, control_queue)

--- a/OlivOS/adapter/onebotV11/onebotSDK.py
+++ b/OlivOS/adapter/onebotV11/onebotSDK.py
@@ -1293,6 +1293,8 @@ class event_action(object):
             this_msg.data.name = name
         if folder_id is not None:
             this_msg.data.folder_id = folder_id
+        elif hasattr(this_msg.data, 'folder_id'):
+            del this_msg.data.folder_id
         this_msg.do_api(control_queue=control_queue)
 
     def delete_group_file(target_event, group_id, file_id, name=None):

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -139,6 +139,7 @@ class payload_template(object):
 
     class data_T(object):
         def __init__(self):
+            self.id = None
             self.op = None
             self.d = None
             self.s = None
@@ -155,6 +156,11 @@ class payload_template(object):
     def load(self, data, is_rx):
         if data is not None:
             if type(data) is dict:
+                if 'id' in data:
+                    if type(data['id']) is str:
+                        self.data.id = data['id']
+                    else:
+                        self.active = False
                 if 'op' in data:
                     if type(data['op']) is int:
                         self.data.op = data['op']
@@ -1143,6 +1149,15 @@ def get_Event_from_SDK(target_event):
             if plugin_event_bot_hash in sdkSubSelfInfo:
                 target_event.data.extend['sub_self_id'] = str(sdkSubSelfInfo[plugin_event_bot_hash])
 
+    event_id = target_event.sdk_event.payload.data.id
+    if (
+        target_event.active
+        and event_id is not None
+        and hasattr(target_event.data, 'extend')
+        and type(target_event.data.extend) is dict
+    ):
+        target_event.data.extend['event_id'] = str(event_id)
+
 
 # 支持OlivOS API调用的方法实现
 class event_action(object):
@@ -1310,6 +1325,108 @@ class event_action(object):
                 msg_id,
                 flag_direct=flag_direct
             )
+
+    def create_markdown_message(
+        target_event,
+        chat_type,
+        chat_id,
+        markdown,
+        msg_id=None,
+        event_id=None,
+        keyboard=None
+    ):
+        res_data = OlivOS.contentAPI.api_result_data_template.universal_result()
+        res_data['data']['chat_type'] = str(chat_type)
+        res_data['data']['chat_id'] = None if chat_id is None else str(chat_id)
+
+        if chat_type not in ['qq_group', 'qq_private', 'guild_channel', 'guild_private']:
+            res_data['data']['error'] = 'unsupported chat_type'
+            return res_data
+        if chat_id is None or str(chat_id) == '':
+            res_data['data']['error'] = 'chat_id is required'
+            return res_data
+        if type(markdown) is not dict or len(markdown) == 0:
+            res_data['data']['error'] = 'markdown must be a non-empty dict'
+            return res_data
+
+        flag_content = (
+            type(markdown.get('content', None)) is str
+            and markdown.get('content', '') != ''
+        )
+        flag_template = (
+            type(markdown.get('custom_template_id', None)) is str
+            and markdown.get('custom_template_id', '') != ''
+        )
+        if flag_content == flag_template:
+            res_data['data']['error'] = 'markdown requires either content or custom_template_id'
+            return res_data
+        if 'params' in markdown and type(markdown['params']) is not list:
+            res_data['data']['error'] = 'markdown params must be a list'
+            return res_data
+        if keyboard is not None and type(keyboard) is not dict:
+            res_data['data']['error'] = 'keyboard must be a dict'
+            return res_data
+        if msg_id is not None and event_id is not None:
+            res_data['data']['error'] = 'msg_id and event_id are mutually exclusive'
+            return res_data
+
+        this_msg = None
+        if chat_type == 'qq_group':
+            this_msg = API.sendQQMessage(get_SDK_bot_info_from_Event(target_event))
+            this_msg.metadata.group_openid = str(chat_id)
+            this_msg.data.msg_type = 2
+        elif chat_type == 'qq_private':
+            this_msg = API.sendQQDirectMessage(get_SDK_bot_info_from_Event(target_event))
+            this_msg.metadata.openid = str(chat_id)
+            this_msg.data.msg_type = 2
+        elif chat_type == 'guild_channel':
+            this_msg = API.sendMessage(get_SDK_bot_info_from_Event(target_event))
+            this_msg.metadata.channel_id = str(chat_id)
+        elif chat_type == 'guild_private':
+            this_msg = API.sendDirectMessage(get_SDK_bot_info_from_Event(target_event))
+            this_msg.metadata.guild_id = str(chat_id)
+
+        this_msg.data.markdown = markdown
+        this_msg.data.keyboard = keyboard
+        this_msg.data.msg_id = None if msg_id is None else str(msg_id)
+        this_msg.data.event_id = None if event_id is None else str(event_id)
+        if msg_id is not None and chat_type in ['qq_group', 'qq_private']:
+            this_msg.data.msg_seq = get_msgid(str(msg_id))
+
+        api_res = this_msg.do_api()
+        raw_obj = init_api_json(api_res)
+        api_code = raw_obj.get('code', None) if type(raw_obj) is dict else None
+        res_data['active'] = (
+            this_msg.res_code is not None
+            and 200 <= this_msg.res_code < 300
+            and api_code in [None, 0]
+        )
+        res_data['data']['response'] = raw_obj if raw_obj is not None else api_res
+        if type(raw_obj) is dict:
+            message_id = raw_obj.get('id', None)
+            if message_id is None and type(raw_obj.get('data', None)) is dict:
+                message_id = raw_obj['data'].get('id', None)
+            if message_id is not None:
+                res_data['data']['message_id'] = str(message_id)
+
+        if not res_data['active'] and target_event.log_func is not None:
+            response_text = str(api_res) if api_res is not None else 'no response'
+            if len(response_text) > 1000:
+                response_text = response_text[:1000] + '...'
+            response_code = 'n/a' if this_msg.res_code is None else str(this_msg.res_code)
+            target_event.log_func(
+                3,
+                (
+                    'OlivOS qqGuildv2SDK Markdown message response: '
+                    f'HTTP {response_code} {response_text}'
+                ),
+                [
+                    (target_event.getBotIDStr(), 'default'),
+                    (modelName, 'default'),
+                    ('create_markdown_message', 'callback')
+                ]
+            )
+        return res_data
 
     def _send_qq_payload(
         target_event,
@@ -1598,6 +1715,59 @@ class event_action(object):
             traceback.print_exc()
             res = None
         return res
+
+
+class inde_interface(OlivOS.API.inde_interface_T):
+    @OlivOS.API.Event.callbackLogger(
+        'qqGuildv2:create_markdown_message',
+        ['chat_type', 'chat_id', 'message_id']
+    )
+    def __create_markdown_message(
+        target_event,
+        chat_type,
+        chat_id,
+        markdown,
+        msg_id=None,
+        event_id=None,
+        keyboard=None,
+        flag_log=True
+    ):
+        return OlivOS.qqGuildv2SDK.event_action.create_markdown_message(
+            target_event=target_event,
+            chat_type=chat_type,
+            chat_id=chat_id,
+            markdown=markdown,
+            msg_id=msg_id,
+            event_id=event_id,
+            keyboard=keyboard
+        )
+
+    def create_markdown_message(
+        self,
+        chat_type,
+        chat_id,
+        markdown,
+        msg_id=None,
+        event_id=None,
+        keyboard=None,
+        flag_log=True,
+        remote=False
+    ):
+        res_data = None
+        if remote:
+            pass
+        else:
+            res_data = inde_interface.__create_markdown_message(
+                self.event,
+                chat_type,
+                chat_id,
+                markdown,
+                msg_id=msg_id,
+                event_id=event_id,
+                keyboard=keyboard,
+                flag_log=flag_log
+            )
+        return res_data
 
 
 def get_msgid(key: str):

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -1356,12 +1356,13 @@ class event_action(object):
         res_text = str(api_obj.res) if api_obj.res is not None else 'no response'
         if len(res_text) > 1000:
             res_text = res_text[:1000] + '...'
+        res_code_text = 'n/a' if api_obj.res_code is None else str(api_obj.res_code)
         target_event.log_func(
             2 if flag_success else 3,
             'OlivOS qqGuildv2SDK QQ %s %s message response: HTTP %s %s' % (
                 chat_type,
                 send_mode,
-                str(api_obj.res_code),
+                res_code_text,
                 res_text
             ),
             [

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -251,6 +251,8 @@ class api_templet(object):
                 self.host = sdkAPIHost['sandbox']
 
     def do_api_plant(self, req_type='POST'):
+        self.res = None
+        self.res_code = None
         try:
             self.__switch_host()
             tmp_payload_dict = {}
@@ -283,6 +285,8 @@ class api_templet(object):
             return None
 
     def do_api(self, req_type='POST'):
+        self.res = None
+        self.res_code = None
         try:
             self.__switch_host()
             tmp_payload_dict = {}

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -1770,6 +1770,21 @@ class inde_interface(OlivOS.API.inde_interface_T):
         return res_data
 
 
+class markdown_tag:
+    def at_user(user_id):
+        return '<qqbot-at-user id="%s" />' % str(user_id)
+
+    def cmd_enter(text):
+        return '<qqbot-cmd-enter text="%s" />' % parse.quote(str(text), safe='')
+
+    def cmd_input(text, show=None, reference=False):
+        res = '<qqbot-cmd-input text="%s"' % parse.quote(str(text), safe='')
+        if show is not None:
+            res += ' show="%s"' % parse.quote(str(show), safe='')
+        res += ' reference="%s" />' % ('true' if reference else 'false')
+        return res
+
+
 def get_msgid(key: str):
     res = sdkMsgidinfo.get(key, 0)
     if type(res) is int:

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -243,6 +243,7 @@ class api_templet(object):
         self.port = 443
         self.route = None
         self.res = None
+        self.res_code = None
 
     def __switch_host(self):
         if self.bot_info.model in ['sandbox', 'sandbox_intents']:
@@ -276,6 +277,7 @@ class api_templet(object):
                 msg_res = req.request("GET", send_url, headers=headers)
 
             self.res = msg_res.text
+            self.res_code = msg_res.status_code
             return msg_res.text
         except Exception:
             return None
@@ -312,6 +314,7 @@ class api_templet(object):
                 msg_res = req.request("DELETE", send_url, headers=headers)
 
             self.res = msg_res.text
+            self.res_code = msg_res.status_code
             # print(self.res)
             return msg_res.text
         except Exception:
@@ -1230,8 +1233,6 @@ class event_action(object):
 
     def send_qq_msg(target_event, chat_id, message, reply_msg_id=None, flag_direct=False):
         msg_id = reply_msg_id
-        if msg_id is None and type(target_event.sdk_event) is event:
-            msg_id = target_event.sdk_event.payload.data.d.get('id', None)
 
         failed_text_buffer = ''
         for text_content, message_this in event_action._get_qq_message_send_chunks(message):
@@ -1328,7 +1329,47 @@ class event_action(object):
             this_msg.data.media = {'file_info': file_info}
         if msg_id is not None:
             this_msg.data.msg_seq = get_msgid(str(msg_id))
-        return this_msg.do_api()
+        api_res = this_msg.do_api()
+        event_action._log_qq_send_result(
+            target_event,
+            this_msg,
+            msg_id,
+            flag_direct=flag_direct
+        )
+        return api_res
+
+    def _log_qq_send_result(target_event, api_obj, msg_id, flag_direct=False):
+        if target_event.log_func is None:
+            return
+        res_obj = init_api_json(api_obj.res)
+        api_code = res_obj.get('code', None) if type(res_obj) is dict else None
+        flag_success = (
+            api_obj.res_code is not None
+            and 200 <= api_obj.res_code < 300
+            and api_code in [None, 0]
+        )
+        # 被动回复沿用现有简洁日志；主动消息额外记录平台结果，便于排查权限和审核问题。
+        if flag_success and msg_id is not None:
+            return
+        send_mode = 'active' if msg_id is None else 'reply'
+        chat_type = 'direct' if flag_direct else 'group'
+        res_text = str(api_obj.res) if api_obj.res is not None else 'no response'
+        if len(res_text) > 1000:
+            res_text = res_text[:1000] + '...'
+        target_event.log_func(
+            2 if flag_success else 3,
+            'OlivOS qqGuildv2SDK QQ %s %s message response: HTTP %s %s' % (
+                chat_type,
+                send_mode,
+                str(api_obj.res_code),
+                res_text
+            ),
+            [
+                (target_event.getBotIDStr(), 'default'),
+                (modelName, 'default'),
+                ('send_qq_msg', 'callback')
+            ]
+        )
 
     def send_msg(target_event, chat_id, message, reply_msg_id=None, flag_direct=False):
         # 频道图片沿用 QQ 图文的双向分组规则。

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -1199,6 +1199,7 @@ class event_action(object):
             OlivOS.messageAPI.PARA.image,
             OlivOS.messageAPI.PARA.video,
             OlivOS.messageAPI.PARA.record,
+            OlivOS.messageAPI.PARA.music,
             OlivOS.messageAPI.PARA.file
         )
         bindable_types = (
@@ -1252,6 +1253,8 @@ class event_action(object):
             elif isinstance(message_this, OlivOS.messageAPI.PARA.video):
                 type_path = 'videos'
             elif isinstance(message_this, OlivOS.messageAPI.PARA.record):
+                type_path = 'audios'
+            elif isinstance(message_this, OlivOS.messageAPI.PARA.music):
                 type_path = 'audios'
             elif isinstance(message_this, OlivOS.messageAPI.PARA.file):
                 type_path = 'files'
@@ -1489,14 +1492,21 @@ class event_action(object):
         this_msg.metadata.message_id = str(message_id)
         return this_msg.do_api('DELETE')
 
-    # 优先使用消息段中的 URL，其次使用本地 path/file
+    # 富媒体优先使用 URL；自定义音乐使用 audio 字段中的实际音频资源。
     def _get_message_resource(message_para):
         if message_para.data is None:
             return None
-        for data_key in ['url', 'path', 'file']:
+        if isinstance(message_para, OlivOS.messageAPI.PARA.music):
+            resource_keys = ['audio']
+        else:
+            resource_keys = ['path', 'url', 'file']
+        for data_key in resource_keys:
             data_value = message_para.data.get(data_key, None)
-            if data_value is not None and str(data_value) != '':
-                return str(data_value)
+            if data_value is None:
+                continue
+            data_value = str(data_value)
+            if data_value not in ['', 'None']:
+                return data_value
         return None
 
     # 读取 OlivOS 支持的 base64、data URI、file URI 或本地资源
@@ -1545,8 +1555,8 @@ class event_action(object):
         target_event,
         url: str,
         chat_id,
-        type_path: str = 'images',
-        type_chat: str = 'qq_groups'
+        type_path: str,
+        type_chat: str
     ):
         res = None
         file_type_map = {

--- a/OlivOS/core/core/API.py
+++ b/OlivOS/core/core/API.py
@@ -173,6 +173,8 @@ class Event(object):
         self.indeAPI = inde_interface_T(self, self.platform['platform'])
         if self.platform['sdk'] == 'kaiheila_link':
             self.indeAPI = OlivOS.kaiheilaSDK.inde_interface(self, self.platform['platform'])
+        if self.platform['sdk'] == 'qqGuildv2_link':
+            self.indeAPI = OlivOS.qqGuildv2SDK.inde_interface(self, self.platform['platform'])
         if self.platform['sdk'] == 'mhyVila_link':
             self.indeAPI = OlivOS.mhyVilaSDK.inde_interface(self, self.platform['platform'])
 

--- a/OlivOS/core/core/API.py
+++ b/OlivOS/core/core/API.py
@@ -23,8 +23,10 @@ import traceback
 import inspect
 import ctypes
 import html
+import os
 
 from functools import wraps
+from urllib import parse
 
 import OlivOS
 from OlivOS.core.info.infoAPI import OlivOS_Version  # noqa
@@ -754,6 +756,99 @@ class Event(object):
             tmp_message = tmp_message_obj.get(self.plugin_info['message_mode_rx'])
         return [tmp_message, tmp_message_obj]
 
+    def __support_file_segment_upload(self, send_type, host_id=None):
+        if send_type not in ['private', 'group']:
+            return False
+        if host_id is not None:
+            return False
+        if self.platform['sdk'] == 'milky':
+            return self.platform['model'] in OlivOS.milkyAutoServerAPI.gCheckList
+        if self.platform['sdk'] != 'onebot':
+            return False
+        return (
+            self.platform['model'] in OlivOS.flaskServerAPI.gCheckList
+            or self.platform['model'] in OlivOS.onebotV11HostServerAPI.gCheckList
+            or self.platform['model'] in OlivOS.onebotV11LinkServerAPI.gCheckList
+        )
+
+    def __get_file_segment_data(self, message_para):
+        file_data = message_para.data
+        if not isinstance(file_data, dict):
+            return None, None
+        file_resource = None
+        for data_key in ['path', 'url', 'file']:
+            data_value = file_data.get(data_key)
+            if data_value is None:
+                continue
+            data_value = str(data_value)
+            if data_value not in ['', 'None']:
+                file_resource = data_value
+                break
+        if file_resource is None:
+            return None, None
+
+        resource_parsed = parse.urlparse(file_resource)
+        if resource_parsed.scheme == '' and not os.path.isabs(file_resource):
+            file_resource = OlivOS.contentAPI.resourcePathTransform('files', file_resource)
+
+        file_name = file_data.get('name')
+        if file_name is not None and str(file_name) not in ['', 'None']:
+            return file_resource, str(file_name)
+        resource_parsed = parse.urlparse(file_resource)
+        if resource_parsed.scheme in ['base64', 'data']:
+            return file_resource, 'file'
+        resource_path = parse.unquote(resource_parsed.path)
+        file_name = resource_path.replace('\\', '/').rstrip('/').rsplit('/', 1)[-1]
+        if file_name == '':
+            file_name = 'file'
+        return file_resource, file_name
+
+    def __send_file_segments(self, send_type, target_id, message_obj, host_id=None, flag_log=True):
+        if not self.__support_file_segment_upload(send_type, host_id):
+            return False
+        if not any(isinstance(para, OlivOS.messageAPI.PARA.file) for para in message_obj.data):
+            return False
+
+        message_buffer = []
+
+        def flush_message_buffer():
+            if len(message_buffer) == 0:
+                return
+            message_chunk = OlivOS.messageAPI.Message_templet('olivos_para', message_buffer.copy())
+            self.__send(
+                send_type,
+                target_id,
+                message_chunk,
+                host_id=host_id,
+                flag_log=flag_log
+            )
+            message_buffer.clear()
+
+        for message_para in message_obj.data:
+            if not isinstance(message_para, OlivOS.messageAPI.PARA.file):
+                message_buffer.append(message_para)
+                continue
+            flush_message_buffer()
+            file_resource, file_name = self.__get_file_segment_data(message_para)
+            if file_resource is None:
+                continue
+            if send_type == 'group':
+                self.__upload_group_file(
+                    target_id,
+                    file_resource,
+                    name=file_name,
+                    flag_log=flag_log
+                )
+            else:
+                self.__upload_private_file(
+                    target_id,
+                    file_resource,
+                    file_name,
+                    flag_log=flag_log
+                )
+        flush_message_buffer()
+        return True
+
     def __reply(self, message, flag_log=True):
         flag_type = None
         tmp_message = None
@@ -881,6 +976,14 @@ class Event(object):
         tmp_message_log = None
         [tmp_message, tmp_message_obj] = self.__message_router(message)
         if tmp_message is None:
+            return
+        if self.__send_file_segments(
+            flag_type,
+            target_id,
+            tmp_message_obj,
+            host_id=host_id,
+            flag_log=flag_log
+        ):
             return
         if self.platform['sdk'] == 'terminal_link':
             OlivOS.virtualTerminalSDK.event_action.send_msg(

--- a/OlivOS/core/core/messageAPI.py
+++ b/OlivOS/core/core/messageAPI.py
@@ -593,7 +593,10 @@ class Message_templet(object):
                     elif tmp_data_type_key == 'file':
                         tmp_para_this = PARA.file(
                             file=str(self.get_from_dict(tmp_code_data_dict, ['file'])),
-                            url=str(self.get_from_dict(tmp_code_data_dict, ['url'], None))
+                            path=self.get_from_dict(tmp_code_data_dict, ['path'], None),
+                            url=str(self.get_from_dict(tmp_code_data_dict, ['url'], None)),
+                            name=self.get_from_dict(tmp_code_data_dict, ['name'], None),
+                            size=self.get_from_dict(tmp_code_data_dict, ['size'], None)
                         )
                     elif tmp_data_type_key == 'rps':
                         tmp_para_this = PARA.rps()

--- a/OlivOS/core/core/pluginAPI.py
+++ b/OlivOS/core/core/pluginAPI.py
@@ -135,6 +135,7 @@ class shallow(API.Proc_templet):
         releaseDir('./data/images')
         releaseDir('./data/videos')
         releaseDir('./data/audios')
+        releaseDir('./data/files')
         threading.Thread(target=self.__init_GUI).start()
         # self.set_check_update()
         time.sleep(1)  # 此处延迟用于在终端第一次启动时等待终端初始化，避免日志丢失，后续需要用异步(控制包流程)方案替代


### PR DESCRIPTION
## Summary by Sourcery

Improve cross-platform file segment handling and QQ Guild v2 message sending behavior, including better media resource resolution and logging.

New Features:
- Support segmented file sending by detecting file message segments and uploading them directly for compatible platforms.
- Add richer support for file message parameters, including path, name, and size metadata.

Bug Fixes:
- Fix QQ Guild v2 active versus reply message determination and ensure proper logging of send results.
- Correct handling of optional folder_id when uploading group files via onebot V11 to avoid sending invalid fields.

Enhancements:
- Unify and normalize file URI handling for the Milky adapter, including local paths and data/base64 URIs.
- Extend QQ Guild v2 media handling to support music segments and refine resource selection priority.
- Add file data directory initialization to the plugin runtime environment for consistent storage of uploaded files.
- Add HTTP status tracking to QQ Guild v2 API calls and include truncated response bodies in logs for easier troubleshooting.