### PR TITLE
fix(plugin): 修复主动消息伪事件未恢复插件消息模式的问题

### DIFF
--- a/OlivOS/core/core/API.py
+++ b/OlivOS/core/core/API.py
@@ -153,12 +153,12 @@ class Event(object):
         }
         self.sdk_event = sdk_event
         self.sdk_event_type = type(self.sdk_event)
-        if type(OlivOS.pluginAPI.gProc) is OlivOS.pluginAPI.shallow:
+        if isinstance(OlivOS.pluginAPI.gProc, OlivOS.pluginAPI.shallow):
             self.plugin_info['control_queue'] = OlivOS.pluginAPI.gProc.Proc_info.control_queue
             self.log_func = OlivOS.pluginAPI.gProc.log
         if (
             self.plugin_info['control_queue'] is None
-            and type(Proc) is OlivOS.pluginAPI.shallow
+            and isinstance(Proc, OlivOS.pluginAPI.shallow)
         ):
             self.plugin_info['control_queue'] = Proc.Proc_info.control_queue
         if type(self.log_func) is None:

--- a/OlivOS/core/core/contentAPI.py
+++ b/OlivOS/core/core/contentAPI.py
@@ -304,6 +304,22 @@ def get_Event_from_fake_SDK(target_event):
                         [target_event.platform['model']]
                     )
     target_event.plugin_info['name'] = target_event.sdk_event.fakename
+    plugin_namespace = getattr(target_event.sdk_event, 'plugin_namespace', None)
+    message_mode_tx = getattr(target_event.sdk_event, 'message_mode_tx', None)
+    plugin_identity = plugin_namespace
+    if plugin_identity is None:
+        plugin_identity = target_event.sdk_event.fakename
+    plugin_proc = OlivOS.pluginAPI.gProc
+    if type(plugin_proc) is OlivOS.pluginAPI.shallow:
+        plugin_context = plugin_proc.get_plugin_event_context(plugin_identity)
+        if plugin_context is not None:
+            plugin_namespace = plugin_context.get('namespace')
+            if message_mode_tx is None:
+                message_mode_tx = plugin_context.get('message_mode')
+    if plugin_namespace is not None:
+        target_event.plugin_info['namespace'] = plugin_namespace
+    if message_mode_tx is not None:
+        target_event.plugin_info['message_mode_tx'] = message_mode_tx
     if True:
         if target_event.sdk_event.data['type'] == 'fake_event':
             target_event.active = True
@@ -312,8 +328,18 @@ def get_Event_from_fake_SDK(target_event):
 
 
 class fake_sdk_event(object):
-    def __init__(self, bot_info, data=None, platform=None, fakename='unity'):
+    def __init__(
+        self,
+        bot_info,
+        data=None,
+        platform=None,
+        fakename='unity',
+        plugin_namespace=None,
+        message_mode_tx=None
+    ):
         self.fakename = fakename
+        self.plugin_namespace = plugin_namespace
+        self.message_mode_tx = message_mode_tx
         tmp_platform = {
             'sdk': 'fake',
             'platform': 'fake',

--- a/OlivOS/core/core/contentAPI.py
+++ b/OlivOS/core/core/contentAPI.py
@@ -310,7 +310,7 @@ def get_Event_from_fake_SDK(target_event):
     if plugin_identity is None:
         plugin_identity = target_event.sdk_event.fakename
     plugin_proc = OlivOS.pluginAPI.gProc
-    if type(plugin_proc) is OlivOS.pluginAPI.shallow:
+    if isinstance(plugin_proc, OlivOS.pluginAPI.shallow):
         plugin_context = plugin_proc.get_plugin_event_context(plugin_identity)
         if plugin_context is not None:
             plugin_namespace = plugin_context.get('namespace')

--- a/OlivOS/core/core/pluginAPI.py
+++ b/OlivOS/core/core/pluginAPI.py
@@ -105,6 +105,47 @@ class shallow(API.Proc_templet):
         def __init__(self, sdk_event):
             self.sdk_event = sdk_event
 
+    def get_plugin_event_context(self, plugin_identity):
+        if plugin_identity is None:
+            return None
+        plugin_identity = str(plugin_identity)
+        plugin_models = list(self.plugin_models_dict.values())
+
+        plugin_model = self.plugin_models_dict.get(plugin_identity)
+        if plugin_model is None:
+            namespace_matches = [
+                model_this
+                for model_this in plugin_models
+                if str(model_this.get('namespace', '')) == plugin_identity
+            ]
+            if len(namespace_matches) == 1:
+                plugin_model = namespace_matches[0]
+        if plugin_model is None:
+            name_matches = [
+                model_this
+                for model_this in plugin_models
+                if str(model_this.get('name', '')) == plugin_identity
+            ]
+            if len(name_matches) == 1:
+                plugin_model = name_matches[0]
+        if plugin_model is None:
+            module_matches = [
+                model_this
+                for model_this in plugin_models
+                if str(model_this.get('module_name', '')) == plugin_identity
+            ]
+            if len(module_matches) == 1:
+                plugin_model = module_matches[0]
+        if plugin_model is None:
+            return None
+        return {
+            'namespace': plugin_model.get('namespace'),
+            'message_mode': plugin_model.get(
+                'message_mode',
+                OlivOS.infoAPI.OlivOS_message_mode_tx_default
+            )
+        }
+
     def __init_GUI(self):
         if platform.system() == 'Windows':
             self.Proc_data['main_tk'] = tkinter.Tk()


### PR DESCRIPTION
## Summary by Sourcery

Restore plugin message mode and namespace handling for fake/active SDK events so that proactive messages correctly use the plugin’s configured message mode.

Bug Fixes:
- Ensure proactive fake SDK events correctly inherit and restore the plugin message mode instead of falling back to defaults.

Enhancements:
- Add a helper to resolve plugin event context (namespace and message mode) from various plugin identifiers.
- Extend fake SDK event objects and event conversion logic to carry plugin namespace and transmit message mode metadata.