### PR TITLE
feat(account): 实现账号的开启和关闭

### DIFF
--- a/OlivOS/adapter/discord/discordLinkServerAPI.py
+++ b/OlivOS/adapter/discord/discordLinkServerAPI.py
@@ -161,6 +161,9 @@ def accountFix(bot_info_dict, logger_proc):
     res = {}
     for bot_info_dict_this in bot_info_dict:
         bot_hash = bot_info_dict_this
+        if getattr(bot_info_dict[bot_hash], 'enable', True) is not True:
+            res[bot_hash] = bot_info_dict[bot_hash]
+            continue
         if bot_info_dict[bot_hash].platform['sdk'] == 'discord_link':
             this_msg = OlivOS.discordSDK.API.getMe(
                 OlivOS.discordSDK.get_SDK_bot_info_from_Plugin_bot_info(bot_info_dict[bot_hash]))
@@ -182,6 +185,7 @@ def accountFix(bot_info_dict, logger_proc):
             except Exception:
                 logger_proc.log(3, '[discord] account [' + str(
                     bot_info_dict[bot_hash].id) + '] not hit:\n' + traceback.format_exc())
+                res[bot_info_dict[bot_hash].hash] = bot_info_dict[bot_hash]
                 continue
         else:
             res[bot_info_dict_this] = bot_info_dict[bot_info_dict_this]

--- a/OlivOS/adapter/dodo/dodoLinkServerAPI.py
+++ b/OlivOS/adapter/dodo/dodoLinkServerAPI.py
@@ -47,6 +47,8 @@ class server(OlivOS.API.Proc_templet):
         self.Proc_data['platform_bot_info_dict'] = None
 
     def run(self):
+        if getattr(self.Proc_data['bot_info_dict'], 'enable', True) is not True:
+            return
         self.log(2, 'OlivOS dodo link server [' + self.Proc_name + '] is running')
         while True:
             api_obj = OlivOS.dodoLinkSDK.API.getGateway(

--- a/OlivOS/adapter/dodo/dodoPollServerAPI.py
+++ b/OlivOS/adapter/dodo/dodoPollServerAPI.py
@@ -42,6 +42,12 @@ class server(OlivOS.API.Proc_templet):
         self.Proc_data['bot_info_island_list'] = {}
 
     def run(self):
+        if type(self.Proc_data['bot_info_dict']) is not dict or not any(
+            getattr(bot_info_this, 'enable', True) is True
+            and bot_info_this.platform['sdk'] == 'dodo_poll'
+            for bot_info_this in self.Proc_data['bot_info_dict'].values()
+        ):
+            return
         self.log(2, 'OlivOS dodo poll server [' + self.Proc_name + '] is running')
         while True:
             time.sleep(self.Proc_info.scan_interval)
@@ -51,6 +57,8 @@ class server(OlivOS.API.Proc_templet):
         for bot_info_this in self.Proc_data['bot_info_dict']:
             flag_not_attach = False
             bot_info_this_obj = self.Proc_data['bot_info_dict'][bot_info_this]
+            if getattr(bot_info_this_obj, 'enable', True) is not True:
+                continue
             if bot_info_this_obj.platform['sdk'] == 'dodo_poll':
                 sdk_bot_info_this = OlivOS.dodoSDK.get_SDK_bot_info_from_Plugin_bot_info(bot_info_this_obj)
                 if bot_info_this in self.Proc_data['bot_info_update_id']:

--- a/OlivOS/adapter/dodo/dodobotEAServerAPI.py
+++ b/OlivOS/adapter/dodo/dodobotEAServerAPI.py
@@ -41,6 +41,12 @@ class server(OlivOS.API.Proc_templet):
         self.Proc_data['platform_bot_info_dict'] = None
 
     def run(self):
+        if type(self.Proc_data['bot_info_dict']) is not dict or not any(
+            getattr(bot_info_this, 'enable', True) is True
+            and bot_info_this.platform['sdk'] == 'dodobot_ea'
+            for bot_info_this in self.Proc_data['bot_info_dict'].values()
+        ):
+            return
         self.log(2, 'OlivOS dodobot ea server [' + self.Proc_name + '] is running')
         while True:
             headers = {
@@ -98,6 +104,11 @@ class server(OlivOS.API.Proc_templet):
                         if tmp_recv_pkg_data is not None:
                             for bot_info_this in self.Proc_data['bot_info_dict']:
                                 bot_info_this_obj = self.Proc_data['bot_info_dict'][bot_info_this]
+                                if (
+                                    getattr(bot_info_this_obj, 'enable', True) is not True
+                                    or bot_info_this_obj.platform['sdk'] != 'dodobot_ea'
+                                ):
+                                    continue
                                 if bot_info_this_obj.id in self.Proc_data['platform_bot_info_dict']:
                                     sdk_bot_info_this = OlivOS.dodobotEASDK.get_SDK_bot_info_from_Plugin_bot_info(
                                         bot_info_this_obj,

--- a/OlivOS/adapter/dodo/dodobotEATXAPI.py
+++ b/OlivOS/adapter/dodo/dodobotEATXAPI.py
@@ -41,6 +41,8 @@ class server(OlivOS.API.Proc_templet):
         self.Proc_data['platform_bot_info_dict'] = None
 
     def run(self):
+        if not self.isAccountEnabled():
+            return
         self.log(2, 'OlivOS dodobot ea tx server [' + self.Proc_name + '] is running')
         while True:
             headers = {
@@ -90,6 +92,8 @@ class server(OlivOS.API.Proc_templet):
                                 rx_packet_data = self.Proc_info.rx_queue.get(block=False)
                                 if rx_packet_data.pkg_type == 'send':
                                     rx_packet_data_data = rx_packet_data.data
+                                    if not self.isAccountEnabled(rx_packet_data_data['Account']['Uid']):
+                                        continue
                                     if (
                                         rx_packet_data_data['Account']['Uid']
                                         in self.Proc_data['platform_bot_info_dict']
@@ -106,3 +110,13 @@ class server(OlivOS.API.Proc_templet):
             except Exception:
                 time.sleep(self.Proc_info.scan_interval)
                 continue
+
+    def isAccountEnabled(self, account_id=None):
+        if type(self.Proc_data['bot_info_dict']) is not dict:
+            return False
+        return any(
+            getattr(bot_info_this, 'enable', True) is True
+            and bot_info_this.platform['sdk'] == 'dodobot_ea'
+            and (account_id is None or str(bot_info_this.id) == str(account_id))
+            for bot_info_this in self.Proc_data['bot_info_dict'].values()
+        )

--- a/OlivOS/adapter/fanbook/fanbookPollServerAPI.py
+++ b/OlivOS/adapter/fanbook/fanbookPollServerAPI.py
@@ -104,6 +104,9 @@ def accountFix(bot_info_dict, logger_proc):
     res = {}
     for bot_info_dict_this in bot_info_dict:
         bot_hash = bot_info_dict_this
+        if getattr(bot_info_dict[bot_hash], 'enable', True) is not True:
+            res[bot_hash] = bot_info_dict[bot_hash]
+            continue
         if bot_info_dict[bot_hash].platform['sdk'] == 'fanbook_poll':
             this_msg = OlivOS.fanbookSDK.API.getMe(
                 OlivOS.fanbookSDK.get_SDK_bot_info_from_Plugin_bot_info(bot_info_dict[bot_hash]))
@@ -136,6 +139,7 @@ def accountFix(bot_info_dict, logger_proc):
                 continue
             except Exception:
                 logger_proc.log(2, '[fanbook] account [' + str(bot_info_dict[bot_hash].id) + '] not hit')
+                res[bot_info_dict[bot_hash].hash] = bot_info_dict[bot_hash]
                 continue
         else:
             res[bot_info_dict_this] = bot_info_dict[bot_info_dict_this]

--- a/OlivOS/adapter/kaiheila/kaiheilaLinkServerAPI.py
+++ b/OlivOS/adapter/kaiheila/kaiheilaLinkServerAPI.py
@@ -147,6 +147,9 @@ def accountFix(bot_info_dict, logger_proc):
     res = {}
     for bot_info_dict_this in bot_info_dict:
         bot_hash = bot_info_dict_this
+        if getattr(bot_info_dict[bot_hash], 'enable', True) is not True:
+            res[bot_hash] = bot_info_dict[bot_hash]
+            continue
         if bot_info_dict[bot_hash].platform['sdk'] == 'kaiheila_link':
             this_msg = OlivOS.kaiheilaSDK.API.getMe(
                 OlivOS.kaiheilaSDK.get_SDK_bot_info_from_Plugin_bot_info(bot_info_dict[bot_hash]))
@@ -172,6 +175,7 @@ def accountFix(bot_info_dict, logger_proc):
             except Exception:
                 logger_proc.log(3, '[kaiheila] account [' + str(
                     bot_info_dict[bot_hash].id) + '] not hit:\n' + traceback.format_exc())
+                res[bot_info_dict[bot_hash].hash] = bot_info_dict[bot_hash]
                 continue
         else:
             res[bot_info_dict_this] = bot_info_dict[bot_info_dict_this]

--- a/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
+++ b/OlivOS/adapter/qqGuild/qqGuildv2SDK.py
@@ -1886,6 +1886,25 @@ def _get_message_attachments(attachments):
     return message_list
 
 
+def _get_qq_ark_message_para(event_data):
+    if not isinstance(event_data, dict):
+        return None
+    ark_data = event_data.get('ark_data', None)
+    if not isinstance(ark_data, dict):
+        ark_data = event_data.get('ark', None)
+    if not isinstance(ark_data, dict):
+        return None
+    try:
+        ark_json = json.dumps(
+            ark_data,
+            ensure_ascii=False,
+            separators=(',', ':')
+        )
+    except (TypeError, ValueError):
+        return None
+    return OlivOS.messageAPI.PARA.json(data=ark_json)
+
+
 def _get_qq_author_name(author):
     if not isinstance(author, dict):
         return '用户'
@@ -2132,6 +2151,8 @@ def _get_qq_message_event_extend(event_type, event_data):
     for source_key, target_key in field_map.items():
         if source_key in event_data:
             result[target_key] = copy.deepcopy(event_data[source_key])
+    if 'ark_data' not in event_data and 'ark' in event_data:
+        result['qq_ark_data'] = copy.deepcopy(event_data['ark'])
     if 'message_scene' in event_data:
         result['qq_message_scene'] = copy.deepcopy(safe_message_scene)
         scene_ext = _parse_qq_message_scene_ext(message_scene)
@@ -2873,13 +2894,19 @@ def get_Event_from_SDK(target_event):
         author = event_data.get('author', {})
         message_obj = None
         message_content = event_data.get('content', None)
+        ark_message_para = _get_qq_ark_message_para(event_data)
         # 群 AT 事件会移除机器人自身的 @，但保留其后的前导空格。
         if (
             event_type == 'GROUP_AT_MESSAGE_CREATE'
             and isinstance(message_content, str)
         ):
             message_content = message_content.lstrip(' ')
-        if message_content is not None:
+        if ark_message_para is not None:
+            message_obj = OlivOS.messageAPI.Message_templet(
+                'olivos_para',
+                [ark_message_para]
+            )
+        elif message_content is not None:
             if message_content != '':
                 message_obj = OlivOS.messageAPI.Message_templet(
                     'qqGuildv2_string',
@@ -3024,7 +3051,13 @@ def get_Event_from_SDK(target_event):
     elif target_event.sdk_event.payload.data.t == 'C2C_MESSAGE_CREATE':
         author = event_data.get('author', {})
         message_obj = None
-        if 'content' in event_data:
+        ark_message_para = _get_qq_ark_message_para(event_data)
+        if ark_message_para is not None:
+            message_obj = OlivOS.messageAPI.Message_templet(
+                'olivos_para',
+                [ark_message_para]
+            )
+        elif 'content' in event_data:
             if event_data['content'] != '':
                 message_obj = OlivOS.messageAPI.Message_templet(
                     'qqGuildv2_string',
@@ -3139,7 +3172,13 @@ def get_Event_from_SDK(target_event):
         author = event_data.get('author', {})
         message_content = event_data.get('content', None)
         message_obj = None
-        if message_content is not None:
+        ark_message_para = _get_qq_ark_message_para(event_data)
+        if ark_message_para is not None:
+            message_obj = OlivOS.messageAPI.Message_templet(
+                'olivos_para',
+                [ark_message_para]
+            )
+        elif message_content is not None:
             if message_content != '':
                 message_obj = OlivOS.messageAPI.Message_templet(
                     'qqGuild_string',
@@ -3249,7 +3288,13 @@ def get_Event_from_SDK(target_event):
     elif target_event.sdk_event.payload.data.t == 'DIRECT_MESSAGE_CREATE':
         author = event_data.get('author', {})
         message_obj = None
-        if 'content' in event_data:
+        ark_message_para = _get_qq_ark_message_para(event_data)
+        if ark_message_para is not None:
+            message_obj = OlivOS.messageAPI.Message_templet(
+                'olivos_para',
+                [ark_message_para]
+            )
+        elif 'content' in event_data:
             if event_data['content'] != '':
                 message_obj = OlivOS.messageAPI.Message_templet(
                     'qqGuild_string',

--- a/OlivOS/core/boot/bootAPI.py
+++ b/OlivOS/core/boot/bootAPI.py
@@ -67,6 +67,7 @@ class Entity(object):
         Proc_dict = {}
         Proc_Proc_dict = {}
         Proc_logger_name = []
+        account_bot_info_dict = {}
         plugin_bot_info_dict = {}
         logger_proc = None
 
@@ -474,38 +475,47 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                                     )
                                     Proc_Proc_dict[tmp_Proc_name] = Proc_dict[tmp_Proc_name].start_unity(tmp_proc_mode)
                     elif basic_conf_models_this['type'] == 'account_config':
-                        plugin_bot_info_dict = OlivOS.accountAPI.Account.load(
+                        account_bot_info_dict = OlivOS.accountAPI.Account.load(
                             path=basic_conf_models_this['data']['path'],
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']]
                         )
+                        plugin_bot_info_dict = OlivOS.accountAPI.Account.getEnabledAccountData(
+                            account_bot_info_dict
+                        )
                     elif basic_conf_models_this['type'] == 'account_config_safe':
-                        plugin_bot_info_dict = OlivOS.accountAPI.Account.load(
+                        account_bot_info_dict = OlivOS.accountAPI.Account.load(
                             path=basic_conf_models_this['data']['path'],
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                             safe_mode=True
                         )
+                        plugin_bot_info_dict = OlivOS.accountAPI.Account.getEnabledAccountData(
+                            account_bot_info_dict
+                        )
                     elif basic_conf_models_this['type'] == 'account_fix':
-                        plugin_bot_info_dict = OlivOS.fanbookPollServerAPI.accountFix(
-                            bot_info_dict=plugin_bot_info_dict,
+                        account_bot_info_dict = OlivOS.fanbookPollServerAPI.accountFix(
+                            bot_info_dict=account_bot_info_dict,
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                         )
-                        plugin_bot_info_dict = OlivOS.kaiheilaLinkServerAPI.accountFix(
-                            bot_info_dict=plugin_bot_info_dict,
+                        account_bot_info_dict = OlivOS.kaiheilaLinkServerAPI.accountFix(
+                            bot_info_dict=account_bot_info_dict,
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                         )
-                        plugin_bot_info_dict = OlivOS.discordLinkServerAPI.accountFix(
-                            bot_info_dict=plugin_bot_info_dict,
+                        account_bot_info_dict = OlivOS.discordLinkServerAPI.accountFix(
+                            bot_info_dict=account_bot_info_dict,
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                         )
                         if platform.system() == 'Windows':
                             OlivOS.libEXEModelAPI.accountFix(
-                                bot_info_dict=plugin_bot_info_dict,
+                                bot_info_dict=account_bot_info_dict,
                                 logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                             )
-                        plugin_bot_info_dict = OlivOS.accountAPI.accountFix(
+                        account_bot_info_dict = OlivOS.accountAPI.accountFix(
                             basic_conf_models=basic_conf_models,
-                            bot_info_dict=plugin_bot_info_dict,
+                            bot_info_dict=account_bot_info_dict,
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
+                        )
+                        plugin_bot_info_dict = OlivOS.accountAPI.Account.getEnabledAccountData(
+                            account_bot_info_dict
                         )
                     elif basic_conf_models_this['type'] == 'qqGuild_link':
                         flag_need_enable = False
@@ -826,7 +836,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                             tmp_callbackData = {'res': False}
                             HostUI_obj = OlivOS.multiLoginUIAPI.HostUI(
                                 Model_name=basic_conf_models_this['name'],
-                                Account_data=plugin_bot_info_dict,
+                                Account_data=account_bot_info_dict,
                                 logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
                                 callbackData=tmp_callbackData
                             )
@@ -834,7 +844,10 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                             if tmp_res is not True:
                                 killMain()
                             if HostUI_obj.UIData['flag_commit']:
-                                plugin_bot_info_dict = HostUI_obj.UIData['Account_data']
+                                account_bot_info_dict = HostUI_obj.UIData['Account_data']
+                                plugin_bot_info_dict = OlivOS.accountAPI.Account.getEnabledAccountData(
+                                    account_bot_info_dict
+                                )
                     elif basic_conf_models_this['type'] == 'multiLoginUI_asayc':
                         if platform.system() == 'Windows':
                             main_control.control_queue.put(
@@ -847,7 +860,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                                         'data': {
                                             'action': 'account_edit',
                                             'event': 'account_edit_on',
-                                            'bot_info': plugin_bot_info_dict
+                                            'bot_info': account_bot_info_dict
                                         }
                                     }
                                 ),
@@ -864,7 +877,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                                     tx_queue=None,
                                     control_queue=multiprocessing_dict[basic_conf_models_this['control_queue']],
                                     logger_proc=Proc_dict[basic_conf_models_this['logger_proc']],
-                                    bot_info_dict=plugin_bot_info_dict
+                                    bot_info_dict=account_bot_info_dict
                                 )
                             # if True or 'auto' == tmp_proc_mode_raw:
                             #    tmp_proc_mode = 'processing'
@@ -874,7 +887,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                     elif basic_conf_models_this['type'] == 'account_config_save':
                         OlivOS.accountAPI.Account.save(
                             path=basic_conf_models_this['data']['path'],
-                            Account_data=plugin_bot_info_dict,
+                            Account_data=account_bot_info_dict,
                             logger_proc=Proc_dict[basic_conf_models_this['logger_proc']]
                         )
                     elif basic_conf_models_this['type'] == 'gocqhttp_lib_exe_model':
@@ -1139,7 +1152,10 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                     and 'data' in rx_packet_data.key
                     and type(rx_packet_data.key['data']) is dict
                 ):
-                    plugin_bot_info_dict = rx_packet_data.key['data']
+                    account_bot_info_dict = rx_packet_data.key['data']
+                    plugin_bot_info_dict = OlivOS.accountAPI.Account.getEnabledAccountData(
+                        account_bot_info_dict
+                    )
                     main_control.control_queue.put(
                         main_control.packet(
                             'send', {
@@ -1149,7 +1165,7 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
                                 },
                                 'data': {
                                     'action': 'account_update',
-                                    'data': plugin_bot_info_dict
+                                    'data': account_bot_info_dict
                                 }
                             }
                         ),

--- a/OlivOS/core/core/API.py
+++ b/OlivOS/core/core/API.py
@@ -62,6 +62,7 @@ class bot_info_T(object):
             access_token=access_token
         )
         self.extends = {}
+        self.enable = True
         self.debug_mode = False
         self.getHash()
 

--- a/OlivOS/core/core/accountAPI.py
+++ b/OlivOS/core/core/accountAPI.py
@@ -69,6 +69,11 @@ class Account(object):
                 and dict is type(account_conf_account_this['extends'])
             ):
                 bot_info_tmp.extends = account_conf_account_this['extends']
+            if (
+                'enable' in account_conf_account_this
+                and bool is type(account_conf_account_this['enable'])
+            ):
+                bot_info_tmp.enable = account_conf_account_this['enable']
             bot_info_tmp.debug_mode = account_conf_account_this['debug']
             plugin_bot_info_dict[bot_info_tmp.hash] = bot_info_tmp
             logger_proc.log(2, OlivOS.L10NAPI.getTrans('generate [{0}] account [{1}] as [{2}] ... done', [
@@ -97,10 +102,20 @@ class Account(object):
             tmp_this_account_data['server']['port'] = Account_data_this.post_info.port
             tmp_this_account_data['server']['access_token'] = Account_data_this.post_info.access_token
             tmp_this_account_data['extends'] = Account_data_this.extends
+            tmp_this_account_data['enable'] = getattr(Account_data_this, 'enable', True)
             tmp_this_account_data['debug'] = Account_data_this.debug_mode
             tmp_total_account_data['account'].append(tmp_this_account_data)
         with open(path, 'w', encoding='utf-8') as account_conf_f:
             account_conf_f.write(json.dumps(tmp_total_account_data, indent=4))
+
+    def getEnabledAccountData(Account_data):
+        if type(Account_data) is not dict:
+            return {}
+        return {
+            Account_data_this_key: Account_data[Account_data_this_key]
+            for Account_data_this_key in Account_data
+            if getattr(Account_data[Account_data_this_key], 'enable', True) is True
+        }
 
 
 def accountFix(basic_conf_models, bot_info_dict, logger_proc):
@@ -134,6 +149,9 @@ def accountFix(basic_conf_models, bot_info_dict, logger_proc):
                     basic_conf_models[basic_conf_models_this]['server']['port'] = g.get_free_port()
         for bot_info_dict_this in bot_info_dict:
             Account_data_this = bot_info_dict[bot_info_dict_this]
+            if getattr(Account_data_this, 'enable', True) is not True:
+                res[bot_info_dict_this] = Account_data_this
+                continue
             if platform.system() == 'Windows':
                 if (
                     Account_data_this.platform['model'] in OlivOS.libEXEModelAPI.gCheckList

--- a/OlivOS/libBooter/libEXEModelAPI.py
+++ b/OlivOS/libBooter/libEXEModelAPI.py
@@ -1091,6 +1091,8 @@ def accountFix(bot_info_dict, logger_proc):
     releaseDir('./conf/gocqhttp')
     for bot_info_dict_this in bot_info_dict:
         bot_hash = bot_info_dict_this
+        if getattr(bot_info_dict[bot_hash], 'enable', True) is not True:
+            continue
         if (
             bot_info_dict[bot_hash].platform['sdk'] == 'onebot'
             and bot_info_dict[bot_hash].platform['platform'] == 'qq'

--- a/OlivOS/nativeGUI/multiLoginUIAPI.py
+++ b/OlivOS/nativeGUI/multiLoginUIAPI.py
@@ -185,6 +185,8 @@ class HostUI(object):
         self.UIObject['tree'].tag_configure('account_disabled', foreground='#888888')
         self.UIObject['tree'].bind('<<TreeviewSelect>>', self.tree_update_selected_color)
         self.UIObject['tree'].bind('<Configure>', self.tree_switch_scroll, add='+')
+        # 固定启用列宽度，保留其他列的手动调整能力
+        self.UIObject['tree'].bind('<ButtonPress-1>', self.tree_block_enable_resize, add='+')
         # self.UIObject['tree'].heading('PLATFORM', text='PLATFORM')
         # self.UIObject['tree'].heading('SDK', text='SDK')
         # self.UIObject['tree'].heading('MODEL', text='MODEL')
@@ -675,6 +677,14 @@ class HostUI(object):
 
     def tree_switch_scroll(self, event=None):
         self.UIObject['root'].after_idle(self.tree_switch_refresh)
+
+    def tree_block_enable_resize(self, event):
+        tree = self.UIObject['tree']
+        if (
+            tree.identify_region(event.x, event.y) == 'separator'
+            and tree.identify_column(event.x) == '#1'
+        ):
+            return 'break'
 
     def tree_yview(self, *args):
         self.UIObject['tree'].yview(*args)

--- a/OlivOS/nativeGUI/multiLoginUIAPI.py
+++ b/OlivOS/nativeGUI/multiLoginUIAPI.py
@@ -14,19 +14,17 @@ _  / / /_  /  __  / __ | / /_  / / /____ \
 @Desc      :   None
 '''
 
-import tkinter
 import base64
-import os
+import copy
 import hashlib
+import json
+import os
+import platform
 import random
 import shutil
-import platform
+import tkinter
 import traceback
-import json
-import copy
-
-from tkinter import ttk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 
 import OlivOS
 
@@ -151,17 +149,42 @@ class HostUI(object):
         )
         self.UIObject['root'].configure(bg=self.UIConfig['color_001'])
 
-        self.UIObject['tree'] = ttk.Treeview(self.UIObject['root'])
+        self.UIObject['tree_style'] = ttk.Style(self.UIObject['root'])
+        self.UIObject['tree_style_name'] = 'OlivOSAccount.Treeview'
+        self.UIObject['tree_style'].configure(
+            self.UIObject['tree_style_name'],
+            rowheight=21
+        )
+        self.UIObject['tree_style'].map(
+            self.UIObject['tree_style_name'],
+            foreground=[('selected', '#FFFFFF')]
+        )
+        self.UIObject['tree'] = ttk.Treeview(
+            self.UIObject['root'],
+            style=self.UIObject['tree_style_name']
+        )
+        self.UIObject['tree_switch_dict'] = {}
         self.UIObject['tree']['show'] = 'headings'
         # self.UIObject['tree']['columns'] = ('ID', 'PLATFORM', 'SDK', 'MODEL')
-        self.UIObject['tree']['columns'] = ('ID', 'TYPE')
-        self.UIObject['tree'].column('ID', width=200)
-        self.UIObject['tree'].column('TYPE', width=200)
+        self.UIObject['tree']['columns'] = ('ENABLE', 'ID', 'TYPE')
+        self.UIObject['tree'].column(
+            'ENABLE',
+            width=69,
+            minwidth=69,
+            stretch=False,
+            anchor='center'
+        )
+        self.UIObject['tree'].column('ID', width=180)
+        self.UIObject['tree'].column('TYPE', width=230)
         # self.UIObject['tree'].column('PLATFORM', width=100)
         # self.UIObject['tree'].column('SDK', width=100)
         # self.UIObject['tree'].column('MODEL', width=100)
+        self.UIObject['tree'].heading('ENABLE', text='启用')
         self.UIObject['tree'].heading('ID', text='ID')
         self.UIObject['tree'].heading('TYPE', text='账号类型')
+        self.UIObject['tree'].tag_configure('account_disabled', foreground='#888888')
+        self.UIObject['tree'].bind('<<TreeviewSelect>>', self.tree_update_selected_color)
+        self.UIObject['tree'].bind('<Configure>', self.tree_switch_scroll, add='+')
         # self.UIObject['tree'].heading('PLATFORM', text='PLATFORM')
         # self.UIObject['tree'].heading('SDK', text='SDK')
         # self.UIObject['tree'].heading('MODEL', text='MODEL')
@@ -176,7 +199,7 @@ class HostUI(object):
         self.UIObject['tree_yscroll'] = ttk.Scrollbar(
             self.UIObject['root'],
             orient="vertical",
-            command=self.UIObject['tree'].yview
+            command=self.tree_yview
         )
         self.UIObject['tree_yscroll'].place(
             x=500,
@@ -185,7 +208,7 @@ class HostUI(object):
             height=350
         )
         self.UIObject['tree'].configure(
-            yscrollcommand=self.UIObject['tree_yscroll'].set
+            yscrollcommand=self.tree_yscroll_set
         )
 
         self.tree_UI_Button_init(
@@ -429,26 +452,251 @@ class HostUI(object):
         self.UIObject['tree_rightkey_menu'].post(event.x_root, event.y_root)
 
     def tree_load(self):
+        self.tree_switch_clear()
         tmp_tree_item_children = self.UIObject['tree'].get_children()
         for tmp_tree_item_this in tmp_tree_item_children:
             self.UIObject['tree'].delete(tmp_tree_item_this)
         for Account_hash_this in self.UIData['Account_data']:
-            self.UIObject['tree'].insert(
+            item_id = self.UIObject['tree'].insert(
                 '',
                 0,
                 text=Account_hash_this,
                 values=(
+                    '',
                     self.UIData['Account_data'][Account_hash_this].id,
                     self.get_account_data_type_name(Account_hash_this)
                     # self.UIData['Account_data'][Account_hash_this].platform['platform'],
                     # self.UIData['Account_data'][Account_hash_this].platform['sdk'],
                     # self.UIData['Account_data'][Account_hash_this].platform['model']
+                ),
+                tags=(
+                    ()
+                    if getattr(self.UIData['Account_data'][Account_hash_this], 'enable', True) is True
+                    else ('account_disabled',)
                 )
             )
+            self.tree_switch_add(item_id, Account_hash_this)
+        self.UIObject['root'].update_idletasks()
+        self.tree_switch_refresh()
         if len(self.UIData['Account_data']) <= 0:
             self.frame_show('root_frame_first_root')
         else:
             self.frame_hide('root_frame_first_root')
+
+    def tree_switch_add(self, item_id, account_hash):
+        account = self.UIData['Account_data'][account_hash]
+        variable = tkinter.BooleanVar(
+            master=self.UIObject['root'],
+            value=getattr(account, 'enable', True) is True
+        )
+        switch = tkinter.Canvas(
+            self.UIObject['tree'],
+            highlightthickness=0,
+            borderwidth=0,
+            takefocus=False,
+            background='#FFFFFF',
+            cursor='arrow'
+        )
+        switch.bind(
+            '<Button-1>',
+            lambda event: self.tree_switch_click(event, account_hash)
+        )
+        switch.bind(
+            '<Motion>',
+            lambda event: self.tree_switch_motion(event, account_hash)
+        )
+        switch.bind('<Leave>', lambda event: switch.configure(cursor='arrow'))
+        self.UIObject['tree_switch_dict'][account_hash] = {
+            'item_id': item_id,
+            'variable': variable,
+            'widget': switch
+        }
+
+    def tree_switch_clear(self):
+        for switch_data in self.UIObject.get('tree_switch_dict', {}).values():
+            try:
+                switch_data['widget'].destroy()
+            except Exception:
+                pass
+        self.UIObject['tree_switch_dict'] = {}
+
+    def tree_switch_toggle(self, account_hash):
+        if (
+            account_hash not in self.UIData['Account_data']
+            or account_hash not in self.UIObject['tree_switch_dict']
+        ):
+            return
+        switch_data = self.UIObject['tree_switch_dict'][account_hash]
+        account = self.UIData['Account_data'][account_hash]
+        account.enable = switch_data['variable'].get() is True
+        self.UIObject['tree'].item(
+            switch_data['item_id'],
+            tags=(() if account.enable is True else ('account_disabled',))
+        )
+        self.UIObject['tree'].selection_set(switch_data['item_id'])
+        self.UIObject['tree'].focus(switch_data['item_id'])
+        self.tree_update_selected_color()
+
+    def tree_switch_click(self, event, account_hash):
+        switch_data = self.UIObject.get('tree_switch_dict', {}).get(account_hash)
+        if switch_data is None:
+            return 'break'
+        box_bounds = switch_data.get('box_bounds')
+        if box_bounds is not None and (
+            box_bounds[0] <= event.x <= box_bounds[2]
+            and box_bounds[1] <= event.y <= box_bounds[3]
+        ):
+            switch_data['variable'].set(not switch_data['variable'].get())
+            self.tree_switch_toggle(account_hash)
+        return 'break'
+
+    def tree_switch_motion(self, event, account_hash):
+        switch_data = self.UIObject.get('tree_switch_dict', {}).get(account_hash)
+        if switch_data is None:
+            return
+        box_bounds = switch_data.get('box_bounds')
+        cursor = 'hand2'
+        if box_bounds is None or not (
+            box_bounds[0] <= event.x <= box_bounds[2]
+            and box_bounds[1] <= event.y <= box_bounds[3]
+        ):
+            cursor = 'arrow'
+        switch_data['widget'].configure(cursor=cursor)
+
+    def tree_switch_refresh(self):
+        for switch_data in self.UIObject.get('tree_switch_dict', {}).values():
+            cell_bbox = self.UIObject['tree'].bbox(switch_data['item_id'], '#1')
+            if cell_bbox:
+                switch_width = min(25, cell_bbox[2])
+                switch_height = min(13, cell_bbox[3])
+                switch_data['widget'].place(
+                    x=cell_bbox[0] + (cell_bbox[2] - switch_width) // 2,
+                    y=cell_bbox[1] + (cell_bbox[3] - switch_height) // 2,
+                    width=switch_width,
+                    height=switch_height
+                )
+                switch_data['width'] = switch_width
+                switch_data['height'] = switch_height
+            else:
+                switch_data['widget'].place_forget()
+        self.tree_switch_update_appearance()
+
+    def tree_switch_update_appearance(self):
+        switch_dict = self.UIObject.get('tree_switch_dict', {})
+        if not switch_dict:
+            return
+        for switch_data in switch_dict.values():
+            self.tree_switch_draw(switch_data)
+
+    def tree_switch_draw(self, switch_data):
+        canvas = switch_data['widget']
+        canvas.delete('all')
+        width = switch_data.get('width', 25)
+        height = switch_data.get('height', 13)
+        item_id = switch_data['item_id']
+        canvas_background = '#FFFFFF'
+        selected = item_id in self.UIObject['tree'].selection()
+        if selected:
+            canvas_background = self.UIObject['tree_style'].lookup(
+                self.UIObject['tree_style_name'],
+                'background',
+                ('selected',)
+            ) or '#0078D7'
+        canvas.configure(background=canvas_background)
+
+        enabled = switch_data['variable'].get() is True
+        track_color = '#00A0EA' if enabled else '#A9AEB3'
+        if selected:
+            track_outline_color = '#FFFFFF'
+        else:
+            track_outline_color = '#005B86' if enabled else '#555C62'
+        track_pixel_runs = (
+            (4, 20),
+            (2, 22),
+            (1, 23),
+            (0, 24),
+            (0, 24),
+            (0, 24),
+            (0, 24),
+            (0, 24),
+            (0, 24),
+            (0, 24),
+            (1, 23),
+            (2, 22),
+            (4, 20)
+        )
+        for pixel_top, (pixel_left, pixel_right) in enumerate(track_pixel_runs):
+            canvas.create_rectangle(
+                pixel_left,
+                pixel_top,
+                pixel_right + 1,
+                pixel_top + 1,
+                fill=track_outline_color,
+                outline=''
+            )
+        track_fill_pixel_runs = (
+            None,
+            (4, 20),
+            (3, 21),
+            (2, 22),
+            (1, 23),
+            (1, 23),
+            (1, 23),
+            (1, 23),
+            (1, 23),
+            (2, 22),
+            (3, 21),
+            (4, 20),
+            None
+        )
+        for pixel_top, pixel_run in enumerate(track_fill_pixel_runs):
+            if pixel_run is None:
+                continue
+            pixel_left, pixel_right = pixel_run
+            canvas.create_rectangle(
+                pixel_left,
+                pixel_top,
+                pixel_right + 1,
+                pixel_top + 1,
+                fill=track_color,
+                outline=''
+            )
+        knob_size = height - 4
+        knob_left = width - knob_size - 2 if enabled else 2
+        canvas.create_oval(
+            knob_left,
+            2,
+            knob_left + knob_size - 1,
+            knob_size + 1,
+            fill='#FFFFFF',
+            outline=''
+        )
+        switch_data['box_bounds'] = (0, 0, width - 1, height - 1)
+
+    def tree_switch_scroll(self, event=None):
+        self.UIObject['root'].after_idle(self.tree_switch_refresh)
+
+    def tree_yview(self, *args):
+        self.UIObject['tree'].yview(*args)
+        self.tree_switch_refresh()
+
+    def tree_yscroll_set(self, first, last):
+        self.UIObject['tree_yscroll'].set(first, last)
+        self.UIObject['root'].after_idle(self.tree_switch_refresh)
+
+    def tree_update_selected_color(self, event=None):
+        selected_item_list = self.UIObject['tree'].selection()
+        selected_foreground = '#FFFFFF'
+        if selected_item_list:
+            account_hash = self.UIObject['tree'].item(selected_item_list[0], 'text')
+            account = self.UIData['Account_data'].get(account_hash)
+            if account is not None and getattr(account, 'enable', True) is not True:
+                selected_foreground = '#888888'
+        self.UIObject['tree_style'].map(
+            self.UIObject['tree_style_name'],
+            foreground=[('selected', selected_foreground)]
+        )
+        self.tree_switch_update_appearance()
 
     def tree_edit(self, action):
         hash_key_how = None
@@ -1324,6 +1572,15 @@ class TreeEditUI(object):
                     platform_platform=tmp_platform_platform,
                     platform_model=tmp_platform_model
                 )
+                if (
+                    tmp_action == 'update'
+                    and self.hash_key in self.UIData['Account_data']
+                ):
+                    tmp_res_bot_info.enable = getattr(
+                        self.UIData['Account_data'][self.hash_key],
+                        'enable',
+                        True
+                    )
                 type_this = self.get_type_name(
                     tmp_platform_platform,
                     tmp_platform_sdk,

--- a/OlivOS/nativeGUI/nativeWinUIAPI.py
+++ b/OlivOS/nativeGUI/nativeWinUIAPI.py
@@ -114,6 +114,7 @@ class dock(OlivOS.API.Proc_templet):
         self.UIData['shallow_plugin_data_dict'] = None
         self.UIData['shallow_account_list'] = []
         self.UIData['shallow_account_list_new'] = []
+        self.UIData['shallow_account_list_initialized'] = False
         self.updateShallowMenuList()
 
     def run(self):
@@ -146,6 +147,8 @@ class dock(OlivOS.API.Proc_templet):
                         self.UIData['shallow_cwcb_menu_list'] = None
                         self.UIData['shallow_virtual_terminal_menu_list'] = None
                         self.UIData['shallow_account_menu_list'] = None
+                        self.updateAccountList(flagInit=True)
+                        self.mergeAccountList()
                         self.updateShallowMenuList()
 
     def process_msg(self):
@@ -231,7 +234,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_napcat_menu_list'] is None:
                                     self.UIData['shallow_napcat_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -274,7 +277,7 @@ class dock(OlivOS.API.Proc_templet):
                                     and 'path' in rx_packet_data.key['data']
                                 ):
                                     hash = rx_packet_data.key['data']['hash']
-                                    if hash in self.bot_info:
+                                    if self.isAccountEnabled(hash):
                                         if hash in self.UIObject['root_qrcode_window']:
                                             try:
                                                 self.UIObject['root_qrcode_window'][hash].stop()
@@ -298,7 +301,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_gocqhttp_menu_list'] is None:
                                     self.UIData['shallow_gocqhttp_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -341,7 +344,7 @@ class dock(OlivOS.API.Proc_templet):
                                     and 'path' in rx_packet_data.key['data']
                                 ):
                                     hash = rx_packet_data.key['data']['hash']
-                                    if hash in self.bot_info:
+                                    if self.isAccountEnabled(hash):
                                         if hash in self.UIObject['root_qrcode_window']:
                                             try:
                                                 self.UIObject['root_qrcode_window'][hash].stop()
@@ -375,7 +378,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_walleq_menu_list'] is None:
                                     self.UIData['shallow_walleq_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -418,7 +421,7 @@ class dock(OlivOS.API.Proc_templet):
                                     and 'path' in rx_packet_data.key['data']
                                 ):
                                     hash = rx_packet_data.key['data']['hash']
-                                    if hash in self.bot_info:
+                                    if self.isAccountEnabled(hash):
                                         if hash in self.UIObject['root_qrcode_window']:
                                             try:
                                                 self.UIObject['root_qrcode_window'][hash].stop()
@@ -442,7 +445,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_cwcb_menu_list'] is None:
                                     self.UIData['shallow_cwcb_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -488,7 +491,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_opqbot_menu_list'] is None:
                                     self.UIData['shallow_opqbot_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -542,7 +545,7 @@ class dock(OlivOS.API.Proc_templet):
                                 if self.UIData['shallow_virtual_terminal_menu_list'] is None:
                                     self.UIData['shallow_virtual_terminal_menu_list'] = []
                                 if 'hash' in rx_packet_data.key['data']:
-                                    if rx_packet_data.key['data']['hash'] in self.bot_info:
+                                    if self.isAccountEnabled(rx_packet_data.key['data']['hash']):
                                         tmp_title = '%s' % (
                                             str(
                                                 self.bot_info[rx_packet_data.key['data']['hash']].id
@@ -703,16 +706,26 @@ class dock(OlivOS.API.Proc_templet):
         platform_name = self.getPlatformDisplayName(bot_info)
         return account_name, platform_name
 
+    def isAccountEnabled(self, bot_hash):
+        return (
+            type(self.bot_info) is dict
+            and bot_hash in self.bot_info
+            and getattr(self.bot_info[bot_hash], 'enable', True) is True
+        )
+
     def updateAccountList(self, flagInit=False):
         self.UIData['shallow_account_list_new'] = []
         if self.bot_info and type(self.bot_info) is dict:
             for botHash, bot_info in self.bot_info.items():
+                if getattr(bot_info, 'enable', True) is not True:
+                    continue
                 account_name, platform_name = self.getAccountDisplayInfo(botHash, bot_info, flagInit=flagInit)
                 self.UIData['shallow_account_list_new'].append((botHash, account_name, platform_name))
             self.UIData['shallow_account_list_new'].sort(key=lambda x: x[1])
 
     def mergeAccountList(self):
         self.UIData['shallow_account_list'] = self.UIData['shallow_account_list_new']
+        self.UIData['shallow_account_list_initialized'] = True
         return True
 
     def updateShallowMenuAccountList(self):
@@ -741,9 +754,11 @@ class dock(OlivOS.API.Proc_templet):
         account_items = []
         account_list = self.UIData['shallow_account_list']
         account_count = len(account_list)
-        if 0 == account_count:
+        if not self.UIData['shallow_account_list_initialized']:
             self.updateAccountList(flagInit=True)
             self.mergeAccountList()
+            account_list = self.UIData['shallow_account_list']
+            account_count = len(account_list)
         for botHash, account_name, platform_name in account_list:
             account_items.append(['account_info', f"{account_name} - {platform_name}", botHash])
 
@@ -906,7 +921,7 @@ class dock(OlivOS.API.Proc_templet):
         )
 
     def startGoCqhttpTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_gocqhttp_terminal']:
                 try:
                     self.UIObject['root_gocqhttp_terminal'][hash].lift()
@@ -923,7 +938,7 @@ class dock(OlivOS.API.Proc_templet):
                 self.UIObject['root_gocqhttp_terminal'][hash].start()
 
     def startWalleQTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_walleq_terminal']:
                 try:
                     self.UIObject['root_walleq_terminal'][hash].lift()
@@ -940,7 +955,7 @@ class dock(OlivOS.API.Proc_templet):
                 self.UIObject['root_walleq_terminal'][hash].start()
 
     def startCWCBTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_cwcb_terminal']:
                 try:
                     self.UIObject['root_cwcb_terminal'][hash].lift()
@@ -957,7 +972,7 @@ class dock(OlivOS.API.Proc_templet):
                 self.UIObject['root_cwcb_terminal'][hash].start()
 
     def startOPQBotTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_opqbot_terminal']:
                 try:
                     self.UIObject['root_opqbot_terminal'][hash].lift()
@@ -974,7 +989,7 @@ class dock(OlivOS.API.Proc_templet):
                 self.UIObject['root_opqbot_terminal'][hash].start()
 
     def startNapCatTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_napcat_terminal']:
                 try:
                     self.UIObject['root_napcat_terminal'][hash].lift()
@@ -1011,7 +1026,7 @@ class dock(OlivOS.API.Proc_templet):
         )
 
     def startVirtualTerminalUI(self, hash):
-        if hash in self.bot_info:
+        if self.isAccountEnabled(hash):
             if hash in self.UIObject['root_virtual_terminal_terminal']:
                 try:
                     self.UIObject['root_virtual_terminal_terminal'][hash].lift()
@@ -1261,7 +1276,7 @@ class dock(OlivOS.API.Proc_templet):
     def sendOpenQRcodeUrl(self, hash, url):
         if (
             type(self.bot_info) is dict
-            and hash in self.bot_info
+            and self.isAccountEnabled(hash)
         ):
             try:
                 res = tkinter.messagebox.askquestion(f'请使用账号 {self.bot_info[hash].id} 扫码', "是否使用内置浏览器?")

--- a/conf/account_template.json
+++ b/conf/account_template.json
@@ -2,6 +2,7 @@
     "account" : [
         {
             "id" : 654321,
+            "enable" : true,
             "password" : "123456",
             "sdk_type" : "onebot",
             "platform_type" : "qq",
@@ -18,6 +19,7 @@
         },
         {
             "id" : 7654321,
+            "enable" : true,
             "password" : "1234567",
             "sdk_type" : "telegram_poll",
             "platform_type" : "telegram",


### PR DESCRIPTION
## Summary by Sourcery

Add support for enabling and disabling accounts across the UI, core boot process, and adapters, and ensure disabled accounts are excluded from runtime operations while preserving their configuration.

New Features:
- Introduce an enable flag on accounts and persist it in account configuration load/save logic.
- Add an enable toggle column with visual switches in the multi-login account UI to allow enabling or disabling accounts.
- Expose helper APIs to filter enabled accounts and to check if a given account is enabled before processing it.

Enhancements:
- Update native Windows UI account lists and menus to respect the enable flag and avoid initializing or displaying disabled accounts.
- Adjust boot pipeline to maintain a full account set while only wiring enabled accounts into plugin runtime data.
- Ensure various platform adapters and account fix routines skip or fast-exit for disabled accounts, avoiding unnecessary network connections and checks.